### PR TITLE
Гутянский Алексей. Технология TBB. Повышение контраста полутонового изображения посредством линейной растяжки гистограммы. Вариант 28

### DIFF
--- a/tasks/gutyansky_a_img_contrast_incr/tbb/include/ops_tbb.hpp
+++ b/tasks/gutyansky_a_img_contrast_incr/tbb/include/ops_tbb.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "gutyansky_a_img_contrast_incr/common/include/common.hpp"
+#include "task/include/task.hpp"
+
+namespace gutyansky_a_img_contrast_incr {
+
+class GutyanskyAImgContrastIncrTBB : public BaseTask {
+ public:
+  static constexpr ppc::task::TypeOfTask GetStaticTypeOfTask() {
+    return ppc::task::TypeOfTask::kTBB;
+  }
+  explicit GutyanskyAImgContrastIncrTBB(const InType &in);
+
+ private:
+  bool ValidationImpl() override;
+  bool PreProcessingImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+};
+
+}  // namespace gutyansky_a_img_contrast_incr

--- a/tasks/gutyansky_a_img_contrast_incr/tbb/src/ops_tbb.cpp
+++ b/tasks/gutyansky_a_img_contrast_incr/tbb/src/ops_tbb.cpp
@@ -1,0 +1,73 @@
+#include "gutyansky_a_img_contrast_incr/tbb/include/ops_tbb.hpp"
+
+#include <tbb/tbb.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <utility>
+
+#include "gutyansky_a_img_contrast_incr/common/include/common.hpp"
+#include "oneapi/tbb/blocked_range.h"
+#include "oneapi/tbb/parallel_for.h"
+
+namespace gutyansky_a_img_contrast_incr {
+
+GutyanskyAImgContrastIncrTBB::GutyanskyAImgContrastIncrTBB(const InType &in) {
+  SetTypeOfTask(GetStaticTypeOfTask());
+  GetInput() = in;
+  GetOutput() = {};
+}
+
+bool GutyanskyAImgContrastIncrTBB::ValidationImpl() {
+  return !GetInput().empty();
+}
+
+bool GutyanskyAImgContrastIncrTBB::PreProcessingImpl() {
+  GetOutput().resize(GetInput().size());
+  return true;
+}
+
+bool GutyanskyAImgContrastIncrTBB::RunImpl() {
+  const auto &input = GetInput();
+  auto &output = GetOutput();
+
+  const size_t sz = input.size();
+  auto [lower_bound, upper_bound] = tbb::parallel_reduce(
+      tbb::blocked_range<size_t>(0, sz), std::make_pair(static_cast<uint8_t>(255), static_cast<uint8_t>(0)),
+      [&input](const auto &range, auto init) {
+    auto [local_min, local_max] = init;
+    for (size_t i = range.begin(); i != range.end(); ++i) {
+      local_min = std::min(local_min, input[i]);
+      local_max = std::max(local_max, input[i]);
+    }
+    return std::make_pair(local_min, local_max);
+  }, [](auto a, auto b) { return std::make_pair(std::min(a.first, b.first), std::max(a.second, b.second)); });
+
+  uint8_t delta = upper_bound - lower_bound;
+
+  if (delta == 0) {
+    tbb::parallel_for(tbb::blocked_range<size_t>(0, sz), [&](const auto &range) {
+      for (auto idx = range.begin(); idx != range.end(); ++idx) {
+        output[idx] = input[idx];
+      }
+    });
+  } else {
+    constexpr uint16_t kMaxUint8 = std::numeric_limits<uint8_t>::max();
+    tbb::parallel_for(tbb::blocked_range<size_t>(0, sz), [&](const auto &range) {
+      for (auto idx = range.begin(); idx != range.end(); ++idx) {
+        uint16_t old_value = input[idx];
+        uint16_t new_value = (kMaxUint8 * (old_value - lower_bound)) / delta;
+        output[idx] = static_cast<uint8_t>(new_value);
+      }
+    });
+  }
+
+  return true;
+}
+
+bool GutyanskyAImgContrastIncrTBB::PostProcessingImpl() {
+  return true;
+}
+
+}  // namespace gutyansky_a_img_contrast_incr

--- a/tasks/gutyansky_a_img_contrast_incr/tests/functional/main.cpp
+++ b/tasks/gutyansky_a_img_contrast_incr/tests/functional/main.cpp
@@ -12,6 +12,7 @@
 #include "gutyansky_a_img_contrast_incr/common/include/common.hpp"
 #include "gutyansky_a_img_contrast_incr/omp/include/ops_omp.hpp"
 #include "gutyansky_a_img_contrast_incr/seq/include/ops_seq.hpp"
+#include "gutyansky_a_img_contrast_incr/tbb/include/ops_tbb.hpp"
 #include "util/include/func_test_util.hpp"
 #include "util/include/util.hpp"
 
@@ -79,6 +80,8 @@ const std::array<TestType, 10> kTestParam = {"test_1", "test_2", "test_3", "test
 const auto kTestTasksList = std::tuple_cat(ppc::util::AddFuncTask<GutyanskyAImgContrastIncrSEQ, InType>(
                                                kTestParam, PPC_SETTINGS_gutyansky_a_img_contrast_incr),
                                            ppc::util::AddFuncTask<GutyanskyAImgContrastIncrOMP, InType>(
+                                               kTestParam, PPC_SETTINGS_gutyansky_a_img_contrast_incr),
+                                           ppc::util::AddFuncTask<GutyanskyAImgContrastIncrTBB, InType>(
                                                kTestParam, PPC_SETTINGS_gutyansky_a_img_contrast_incr));
 
 const auto kGtestValues = ppc::util::ExpandToValues(kTestTasksList);

--- a/tasks/gutyansky_a_img_contrast_incr/tests/performance/main.cpp
+++ b/tasks/gutyansky_a_img_contrast_incr/tests/performance/main.cpp
@@ -6,6 +6,7 @@
 #include "gutyansky_a_img_contrast_incr/common/include/common.hpp"
 #include "gutyansky_a_img_contrast_incr/omp/include/ops_omp.hpp"
 #include "gutyansky_a_img_contrast_incr/seq/include/ops_seq.hpp"
+#include "gutyansky_a_img_contrast_incr/tbb/include/ops_tbb.hpp"
 #include "util/include/perf_test_util.hpp"
 
 namespace gutyansky_a_img_contrast_incr {
@@ -40,8 +41,8 @@ TEST_P(GutyanskyARunPerfTestsImgContrastIncr, RunPerfModes) {
 namespace {
 
 const auto kAllPerfTasks =
-    ppc::util::MakeAllPerfTasks<InType, GutyanskyAImgContrastIncrSEQ, GutyanskyAImgContrastIncrOMP>(
-        PPC_SETTINGS_gutyansky_a_img_contrast_incr);
+    ppc::util::MakeAllPerfTasks<InType, GutyanskyAImgContrastIncrSEQ, GutyanskyAImgContrastIncrOMP,
+                                GutyanskyAImgContrastIncrTBB>(PPC_SETTINGS_gutyansky_a_img_contrast_incr);
 
 const auto kGtestValues = ppc::util::TupleToGTestValues(kAllPerfTasks);
 


### PR DESCRIPTION
## Описание

- **Задача**: _Повышение контраста полутонового изображения посредством линейной растяжки гистограммы_
- **Вариант**: _28_
- **Технология**: _TBB_
- **Описание**
  _Для хранения данных используется std::vector<uint8_t>, что соответствует полутоновому изображению с 256 оттенками серого. Обработка происходит в два этапа. На первом этапе вычисляются минимальная и максимальная яркости пикселей с помощью параллельной операции reduce (tbb::parallel_reduce, используется blocked_range, минимумы и максимумы вычисляются отдельно по блокам, потом сливаются в общее значение). Если все яркости равны, то выходное изображение в точности равно исходному (происходит копирование входных данных в выходной буфер с использованием tbb::parallel_for). В ином случае каждый пиксель преобразуется по формуле new_value = 255 * (old_value - min_brightness) / (max_brightness - min_brightness). Во избежание переполнения uint8_t вычисления производятся в uint16_t. Обработка пикселей распределяется между потоками. (используется также tbb::parallel_for)_

---

## Чек-лист
<!--
Пожалуйста, убедитесь, что следующие пункты выполнены **до** отправки pull request'а и запроса его ревью:
-->

- [x] **Статус CI**: Все CI-задачи (сборка, тесты, генерация отчёта) успешно проходят на моей ветке в моем форке
- [x] **Директория и именование задачи**: Я создал директорию с именем `<фамилия>_<первая_буква_имени>_<короткое_название_задачи>`
- [x] **Полное описание задачи**: Я предоставил полное описание задачи в теле pull request
- [x] **clang-format**: Мои изменения успешно проходят `clang-format` локально в моем форке (нет ошибок форматирования)
- [x] **clang-tidy**: Мои изменения успешно проходят `clang-tidy` локально в моем форке (нет предупреждений/ошибок)
- [x] **Функциональные тесты**: Все функциональные тесты успешно проходят локально на моей машине
- [x] **Тесты производительности**: Все тесты производительности успешно проходят локально на моей машине
- [x] **Ветка**: Я работаю в ветке, названной точно так же, как директория моей задачи
  (например, `nesterov_a_vector_sum`), а не в `master`
- [x] **Правдивое содержание**: Я подтверждаю, что все сведения, указанные в этом pull request, являются точными и
  достоверными

<!--
ПРИМЕЧАНИЕ: Ложные сведения в этом чек-листе могут привести к отклонению PR и получению нулевого балла
за соответствующую задачу.
-->