### PR TITLE
Зенин Антон. Технология STL. Поразрядная сортировка для вещественных чисел (тип double) с четно-нечетным слиянием Бэтчера. Вариант 20

### DIFF
--- a/tasks/zenin_a_radix_sort_double_batcher_merge/stl/include/ops_stl.hpp
+++ b/tasks/zenin_a_radix_sort_double_batcher_merge/stl/include/ops_stl.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#include "task/include/task.hpp"
+#include "zenin_a_radix_sort_double_batcher_merge/common/include/common.hpp"
+
+namespace zenin_a_radix_sort_double_batcher_merge {
+
+class ZeninARadixSortDoubleBatcherMergeSTL : public BaseTask {
+ public:
+  static constexpr ppc::task::TypeOfTask GetStaticTypeOfTask() {
+    return ppc::task::TypeOfTask::kSTL;
+  }
+  explicit ZeninARadixSortDoubleBatcherMergeSTL(const InType &in);
+
+ private:
+  bool ValidationImpl() override;
+  bool PreProcessingImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+
+  static void BlocksComparing(std::vector<double> &arr, size_t i, size_t j);
+  static uint64_t PackDouble(double v) noexcept;
+  static double UnpackDouble(uint64_t k) noexcept;
+  static void LSDRadixSort(std::vector<double> &arr);
+  static void BatcherOddEvenMerge(std::vector<double> &arr, size_t n, size_t num_threads);
+};
+
+}  // namespace zenin_a_radix_sort_double_batcher_merge

--- a/tasks/zenin_a_radix_sort_double_batcher_merge/stl/include/ops_stl.hpp
+++ b/tasks/zenin_a_radix_sort_double_batcher_merge/stl/include/ops_stl.hpp
@@ -23,6 +23,7 @@ class ZeninARadixSortDoubleBatcherMergeSTL : public BaseTask {
   bool PostProcessingImpl() override;
 
   static void BlocksComparing(std::vector<double> &arr, size_t i, size_t j);
+  static void MergeFirstPass(std::vector<double> &arr, size_t po, size_t num_threads);
   static uint64_t PackDouble(double v) noexcept;
   static double UnpackDouble(uint64_t k) noexcept;
   static void LSDRadixSort(std::vector<double> &arr);

--- a/tasks/zenin_a_radix_sort_double_batcher_merge/stl/src/ops_stl.cpp
+++ b/tasks/zenin_a_radix_sort_double_batcher_merge/stl/src/ops_stl.cpp
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <cstring>
 #include <limits>
+#include <thread>
 #include <utility>
 #include <vector>
 

--- a/tasks/zenin_a_radix_sort_double_batcher_merge/stl/src/ops_stl.cpp
+++ b/tasks/zenin_a_radix_sort_double_batcher_merge/stl/src/ops_stl.cpp
@@ -1,0 +1,182 @@
+#include "zenin_a_radix_sort_double_batcher_merge/stl/include/ops_stl.hpp"
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <utility>
+#include <vector>
+
+#include "zenin_a_radix_sort_double_batcher_merge/common/include/common.hpp"
+
+namespace zenin_a_radix_sort_double_batcher_merge {
+
+ZeninARadixSortDoubleBatcherMergeSTL::ZeninARadixSortDoubleBatcherMergeSTL(const InType &in) {
+  SetTypeOfTask(GetStaticTypeOfTask());
+  GetInput() = in;
+  GetOutput() = {};
+}
+
+bool ZeninARadixSortDoubleBatcherMergeSTL::ValidationImpl() {
+  return true;
+}
+
+bool ZeninARadixSortDoubleBatcherMergeSTL::PreProcessingImpl() {
+  return true;
+}
+
+void ZeninARadixSortDoubleBatcherMergeSTL::BlocksComparing(std::vector<double> &arr, size_t i, size_t j) {
+  if (arr[i] > arr[j]) {
+    std::swap(arr[i], arr[j]);
+  }
+}
+
+uint64_t ZeninARadixSortDoubleBatcherMergeSTL::PackDouble(double v) noexcept {
+  uint64_t bits = 0ULL;
+  std::memcpy(&bits, &v, sizeof(bits));
+  if ((bits & (1ULL << 63)) != 0ULL) {
+    bits = ~bits;
+  } else {
+    bits ^= (1ULL << 63);
+  }
+  return bits;
+}
+
+double ZeninARadixSortDoubleBatcherMergeSTL::UnpackDouble(uint64_t k) noexcept {
+  if ((k & (1ULL << 63)) != 0ULL) {
+    k ^= (1ULL << 63);
+  } else {
+    k = ~k;
+  }
+  double v = 0.0;
+  std::memcpy(&v, &k, sizeof(v));
+  return v;
+}
+
+void ZeninARadixSortDoubleBatcherMergeSTL::LSDRadixSort(std::vector<double> &array) {
+  const std::size_t n = array.size();
+  if (n <= 1U) {
+    return;
+  }
+
+  constexpr int kBits = 8;
+  constexpr int kBuckets = 1 << kBits;
+  constexpr int kPasses = static_cast<int>((sizeof(uint64_t) * 8) / kBits);
+
+  std::vector<uint64_t> keys;
+  keys.resize(n);
+  for (std::size_t i = 0; i < n; ++i) {
+    keys[i] = PackDouble(array[i]);
+  }
+
+  std::vector<uint64_t> tmp_keys;
+  tmp_keys.resize(n);
+  std::vector<double> tmp_vals;
+  tmp_vals.resize(n);
+
+  for (int pass = 0; pass < kPasses; ++pass) {
+    int shift = pass * kBits;
+    std::vector<std::size_t> cnt;
+    cnt.assign(kBuckets + 1, 0U);
+
+    for (std::size_t i = 0; i < n; ++i) {
+      auto d = static_cast<std::size_t>((keys[i] >> shift) & (kBuckets - 1));
+      ++cnt[d + 1];
+    }
+    for (int i = 0; i < kBuckets; ++i) {
+      cnt[i + 1] += cnt[i];
+    }
+
+    for (std::size_t i = 0; i < n; ++i) {
+      auto d = static_cast<std::size_t>((keys[i] >> shift) & (kBuckets - 1));
+      std::size_t pos = cnt[d]++;
+      tmp_keys[pos] = keys[i];
+      tmp_vals[pos] = array[i];
+    }
+
+    keys.swap(tmp_keys);
+    array.swap(tmp_vals);
+  }
+
+  for (std::size_t i = 0; i < n; ++i) {
+    array[i] = UnpackDouble(keys[i]);
+  }
+}
+
+void ZeninARadixSortDoubleBatcherMergeSTL::BatcherOddEvenMerge(std::vector<double> &arr, size_t n, size_t num_threads) {
+  for (size_t po = n / 2; po > 0; po >>= 1) {
+    if (po == n / 2) {
+      size_t chunk = (po + num_threads - 1) / num_threads;
+      std::vector<std::thread> threads;
+      for (size_t t = 0; t < num_threads; ++t) {
+        size_t lo = t * chunk;
+        size_t hi = std::min(lo + chunk, po);
+        if (lo >= hi) {
+          break;
+        }
+        threads.emplace_back([&arr, lo, hi, po]() {
+          for (size_t i = lo; i < hi; ++i) {
+            BlocksComparing(arr, i, i + po);
+          }
+        });
+      }
+      for (auto &th : threads) {
+        th.join();
+      }
+    } else {
+      for (size_t i = po; i < n - po; i += 2 * po) {
+        for (size_t j = 0; j < po; ++j) {
+          BlocksComparing(arr, i + j, i + j + po);
+        }
+      }
+    }
+  }
+}
+
+bool ZeninARadixSortDoubleBatcherMergeSTL::RunImpl() {
+  auto data = GetInput();
+  size_t original_size = data.size();
+
+  if (original_size <= 1) {
+    GetOutput() = data;
+    return true;
+  }
+
+  int num_threads_int = ppc::util::GetNumThreads();
+  if (num_threads_int <= 0) {
+    num_threads_int = 1;
+  }
+  auto num_threads = static_cast<size_t>(num_threads_int);
+
+  size_t pow2 = 1;
+  while (pow2 < original_size) {
+    pow2 <<= 1;
+  }
+  data.resize(pow2, std::numeric_limits<double>::max());
+
+  size_t half = pow2 / 2;
+  auto half_dist = static_cast<std::ptrdiff_t>(half);
+
+  std::vector<double> left(data.begin(), data.begin() + half_dist);
+  std::vector<double> right(data.begin() + half_dist, data.end());
+
+  std::thread t([&]() { LSDRadixSort(left); });
+  LSDRadixSort(right);
+  t.join();
+
+  std::ranges::copy(left, data.begin());
+  std::ranges::copy(right, data.begin() + half_dist);
+
+  BatcherOddEvenMerge(data, data.size(), num_threads);
+
+  data.resize(original_size);
+  GetOutput() = data;
+  return true;
+}
+
+bool ZeninARadixSortDoubleBatcherMergeSTL::PostProcessingImpl() {
+  return true;
+}
+
+}  // namespace zenin_a_radix_sort_double_batcher_merge

--- a/tasks/zenin_a_radix_sort_double_batcher_merge/stl/src/ops_stl.cpp
+++ b/tasks/zenin_a_radix_sort_double_batcher_merge/stl/src/ops_stl.cpp
@@ -9,6 +9,7 @@
 #include <utility>
 #include <vector>
 
+#include "util/include/util.hpp"
 #include "zenin_a_radix_sort_double_batcher_merge/common/include/common.hpp"
 
 namespace zenin_a_radix_sort_double_batcher_merge {
@@ -105,26 +106,30 @@ void ZeninARadixSortDoubleBatcherMergeSTL::LSDRadixSort(std::vector<double> &arr
   }
 }
 
+void ZeninARadixSortDoubleBatcherMergeSTL::MergeFirstPass(std::vector<double> &arr, size_t po, size_t num_threads) {
+  size_t chunk = (po + num_threads - 1) / num_threads;
+  std::vector<std::thread> threads;
+  for (size_t tid = 0; tid < num_threads; ++tid) {
+    size_t lo = tid * chunk;
+    size_t hi = std::min(lo + chunk, po);
+    if (lo >= hi) {
+      break;
+    }
+    threads.emplace_back([&arr, lo, hi, po]() {
+      for (size_t i = lo; i < hi; ++i) {
+        BlocksComparing(arr, i, i + po);
+      }
+    });
+  }
+  for (auto &th : threads) {
+    th.join();
+  }
+}
+
 void ZeninARadixSortDoubleBatcherMergeSTL::BatcherOddEvenMerge(std::vector<double> &arr, size_t n, size_t num_threads) {
   for (size_t po = n / 2; po > 0; po >>= 1) {
     if (po == n / 2) {
-      size_t chunk = (po + num_threads - 1) / num_threads;
-      std::vector<std::thread> threads;
-      for (size_t t = 0; t < num_threads; ++t) {
-        size_t lo = t * chunk;
-        size_t hi = std::min(lo + chunk, po);
-        if (lo >= hi) {
-          break;
-        }
-        threads.emplace_back([&arr, lo, hi, po]() {
-          for (size_t i = lo; i < hi; ++i) {
-            BlocksComparing(arr, i, i + po);
-          }
-        });
-      }
-      for (auto &th : threads) {
-        th.join();
-      }
+      MergeFirstPass(arr, po, num_threads);
     } else {
       for (size_t i = po; i < n - po; i += 2 * po) {
         for (size_t j = 0; j < po; ++j) {

--- a/tasks/zenin_a_radix_sort_double_batcher_merge/tests/functional/main.cpp
+++ b/tasks/zenin_a_radix_sort_double_batcher_merge/tests/functional/main.cpp
@@ -12,12 +12,12 @@
 // #include <vector>
 
 // #include "zenin_a_radix_sort_double_batcher_merge/all/include/ops_all.hpp"
+#include "util/include/func_test_util.hpp"
+#include "util/include/util.hpp"
 #include "zenin_a_radix_sort_double_batcher_merge/common/include/common.hpp"
 #include "zenin_a_radix_sort_double_batcher_merge/omp/include/ops_omp.hpp"
 #include "zenin_a_radix_sort_double_batcher_merge/seq/include/ops_seq.hpp"
-// #include "zenin_a_radix_sort_double_batcher_merge/stl/include/ops_stl.hpp"
-#include "util/include/func_test_util.hpp"
-#include "util/include/util.hpp"
+#include "zenin_a_radix_sort_double_batcher_merge/stl/include/ops_stl.hpp"
 #include "zenin_a_radix_sort_double_batcher_merge/tbb/include/ops_tbb.hpp"
 
 namespace zenin_a_radix_sort_double_batcher_merge {
@@ -83,6 +83,8 @@ const auto kTestTasksList = std::tuple_cat(ppc::util::AddFuncTask<ZeninARadixSor
                                            ppc::util::AddFuncTask<ZeninARadixSortDoubleBatcherMergeOMP, InType>(
                                                kTestParam, PPC_SETTINGS_zenin_a_radix_sort_double_batcher_merge),
                                            ppc::util::AddFuncTask<ZeninARadixSortDoubleBatcherMergeTBB, InType>(
+                                               kTestParam, PPC_SETTINGS_zenin_a_radix_sort_double_batcher_merge),
+                                           ppc::util::AddFuncTask<ZeninARadixSortDoubleBatcherMergeSTL, InType>(
                                                kTestParam, PPC_SETTINGS_zenin_a_radix_sort_double_batcher_merge));
 
 const auto kGtestValues = ppc::util::ExpandToValues(kTestTasksList);

--- a/tasks/zenin_a_radix_sort_double_batcher_merge/tests/performance/main.cpp
+++ b/tasks/zenin_a_radix_sort_double_batcher_merge/tests/performance/main.cpp
@@ -5,11 +5,11 @@
 #include <random>
 
 // #include "zenin_a_radix_sort_double_batcher_merge/all/include/ops_all.hpp"
+#include "util/include/perf_test_util.hpp"
 #include "zenin_a_radix_sort_double_batcher_merge/common/include/common.hpp"
 #include "zenin_a_radix_sort_double_batcher_merge/omp/include/ops_omp.hpp"
 #include "zenin_a_radix_sort_double_batcher_merge/seq/include/ops_seq.hpp"
-// #include "zenin_a_radix_sort_double_batcher_merge/stl/include/ops_stl.hpp"
-#include "util/include/perf_test_util.hpp"
+#include "zenin_a_radix_sort_double_batcher_merge/stl/include/ops_stl.hpp"
 #include "zenin_a_radix_sort_double_batcher_merge/tbb/include/ops_tbb.hpp"
 
 namespace zenin_a_radix_sort_double_batcher_merge {
@@ -56,7 +56,7 @@ namespace {
 
 const auto kAllPerfTasks =
     ppc::util::MakeAllPerfTasks<InType, ZeninARadixSortDoubleBatcherMergeOMP, ZeninARadixSortDoubleBatcherMergeSeqseq,
-                                ZeninARadixSortDoubleBatcherMergeTBB>(
+                                ZeninARadixSortDoubleBatcherMergeTBB, ZeninARadixSortDoubleBatcherMergeSTL>(
         PPC_SETTINGS_zenin_a_radix_sort_double_batcher_merge);
 
 const auto kGtestValues = ppc::util::TupleToGTestValues(kAllPerfTasks);


### PR DESCRIPTION
<!--
Требования к названию pull request:

"<Фамилия> <Имя>. Технология <TECHNOLOGY_NAME:SEQ|OMP|TBB|STL|MPI>. <Полное название задачи>. Вариант <Номер>"
-->

## Описание
<!--
Пожалуйста, предоставьте подробное описание вашей реализации, включая:
 - основные детали решения (описание выбранного алгоритма)
 - применение технологии параллелизма (если применимо)
-->

- **Задача**: Поразрядная сортировка для вещественных чисел (тип double) с четно-нечетным слиянием Бэтчера
- **Вариант**: 20
- **Технология**:  STL
- **Описание** вашей реализации и отчёта.  
  Реализована параллельная версия поразрядной сортировки (LSD) для чисел типа double с чётно-нечётным слиянием Бэтчера с использованием STL threads. Массив дополняется до ближайшей степени двойки значениями double::max(), затем делится на две половины, каждая из которых сортируется независимо с помощью LSD radix sort — одна половина в отдельном std::thread, вторая в основном потоке. Отсортированные половины сливаются через сеть чётно-нечётного слияния Бэтчера, первый проход которой распараллелен через пул std::thread с числом потоков равным ppc::util::GetNumThreads(). После слияния паддинг удаляется и результат возвращается.

---

## Чек-лист
<!--
Пожалуйста, убедитесь, что следующие пункты выполнены **до** отправки pull request'а и запроса его ревью:
-->

- [x] **Статус CI**: Все CI-задачи (сборка, тесты, генерация отчёта) успешно проходят на моей ветке в моем форке
- [x] **Директория и именование задачи**: Я создал директорию с именем `<фамилия>_<первая_буква_имени>_<короткое_название_задачи>`
- [x] **Полное описание задачи**: Я предоставил полное описание задачи в теле pull request
- [x] **clang-format**: Мои изменения успешно проходят `clang-format` локально в моем форке (нет ошибок форматирования)
- [x] **clang-tidy**: Мои изменения успешно проходят `clang-tidy` локально в моем форке (нет предупреждений/ошибок)
- [x] **Функциональные тесты**: Все функциональные тесты успешно проходят локально на моей машине
- [x] **Тесты производительности**: Все тесты производительности успешно проходят локально на моей машине
- [x] **Ветка**: Я работаю в ветке, названной точно так же, как директория моей задачи
  (например, `nesterov_a_vector_sum`), а не в `master`
- [x] **Правдивое содержание**: Я подтверждаю, что все сведения, указанные в этом pull request, являются точными и
  достоверными

<!--
ПРИМЕЧАНИЕ: Ложные сведения в этом чек-листе могут привести к отклонению PR и получению нулевого балла
за соответствующую задачу.
-->
