### PR TITLE
Дилшодов Адхам. Технология SEQ. Умножение разреженных матриц. Элементы типа double. Формат хранения матрицы – столбцовый (CCS). Вариант 5

### DIFF
--- a/tasks/dilshodov_a_spmm_double_css/common/include/common.hpp
+++ b/tasks/dilshodov_a_spmm_double_css/common/include/common.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <string>
+#include <tuple>
+#include <vector>
+
+#include "task/include/task.hpp"
+
+namespace dilshodov_a_spmm_double_css {
+
+using DenseMatrix = std::vector<std::vector<double>>;
+
+struct SparseMatrixCCS {
+  int rows_count = 0;
+  int cols_count = 0;
+  int non_zeros = 0;
+  std::vector<int> col_ptrs;
+  std::vector<int> row_indices;
+  std::vector<double> values;
+};
+
+using InType = std::tuple<SparseMatrixCCS, SparseMatrixCCS>;
+using OutType = SparseMatrixCCS;
+using TestType = std::tuple<std::string, DenseMatrix, DenseMatrix>;
+using BaseTask = ppc::task::Task<InType, OutType>;
+
+}  // namespace dilshodov_a_spmm_double_css

--- a/tasks/dilshodov_a_spmm_double_css/info.json
+++ b/tasks/dilshodov_a_spmm_double_css/info.json
@@ -1,0 +1,9 @@
+{
+  "student": {
+    "first_name": "Адхам",
+    "group_number": "3823Б1ПР4",
+    "last_name": "Дилшодов",
+    "middle_name": "Умидович",
+    "task_number": "5"
+  }
+}

--- a/tasks/dilshodov_a_spmm_double_css/seq/include/ops_seq.hpp
+++ b/tasks/dilshodov_a_spmm_double_css/seq/include/ops_seq.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "dilshodov_a_spmm_double_css/common/include/common.hpp"
+#include "task/include/task.hpp"
+
+namespace dilshodov_a_spmm_double_css {
+
+class DilshodovASpmmDoubleCssSeq : public BaseTask {
+ public:
+  static constexpr ppc::task::TypeOfTask GetStaticTypeOfTask() {
+    return ppc::task::TypeOfTask::kSEQ;
+  }
+
+  explicit DilshodovASpmmDoubleCssSeq(const InType &in);
+
+ private:
+  bool ValidationImpl() override;
+  bool PreProcessingImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+};
+
+}  // namespace dilshodov_a_spmm_double_css

--- a/tasks/dilshodov_a_spmm_double_css/seq/src/ops_seq.cpp
+++ b/tasks/dilshodov_a_spmm_double_css/seq/src/ops_seq.cpp
@@ -1,0 +1,122 @@
+#include "dilshodov_a_spmm_double_css/seq/include/ops_seq.hpp"
+
+#include <cmath>
+#include <cstddef>
+#include <map>
+#include <utility>
+
+#include "dilshodov_a_spmm_double_css/common/include/common.hpp"
+
+namespace dilshodov_a_spmm_double_css {
+
+namespace {
+constexpr double kEps = 1e-10;
+
+bool HasValidDimensions(const SparseMatrixCCS &m) {
+  return m.rows_count > 0 && m.cols_count > 0;
+}
+
+bool HasValidContainers(const SparseMatrixCCS &m) {
+  if (m.col_ptrs.size() != static_cast<size_t>(m.cols_count) + 1) {
+    return false;
+  }
+  if (m.row_indices.size() != m.values.size()) {
+    return false;
+  }
+  if (m.col_ptrs.empty() || m.col_ptrs.front() != 0) {
+    return false;
+  }
+  if (std::cmp_not_equal(m.col_ptrs.back(), m.values.size())) {
+    return false;
+  }
+
+  return true;
+}
+
+bool HasValidColumnOrdering(const SparseMatrixCCS &m) {
+  for (int j = 0; j < m.cols_count; ++j) {
+    if (m.col_ptrs[j] > m.col_ptrs[j + 1]) {
+      return false;
+    }
+    int prev_row = -1;
+    for (int idx = m.col_ptrs[j]; idx < m.col_ptrs[j + 1]; ++idx) {
+      const int row = m.row_indices[idx];
+      if (row < 0 || row >= m.rows_count) {
+        return false;
+      }
+      if (row <= prev_row) {
+        return false;
+      }
+      prev_row = row;
+    }
+  }
+
+  return true;
+}
+
+bool IsValidCCS(const SparseMatrixCCS &m) {
+  return HasValidDimensions(m) && HasValidContainers(m) && HasValidColumnOrdering(m);
+}
+
+}  // namespace
+
+DilshodovASpmmDoubleCssSeq::DilshodovASpmmDoubleCssSeq(const InType &in) {
+  SetTypeOfTask(GetStaticTypeOfTask());
+  GetInput() = in;
+}
+
+bool DilshodovASpmmDoubleCssSeq::ValidationImpl() {
+  const auto &matrix_a = std::get<0>(GetInput());
+  const auto &matrix_b = std::get<1>(GetInput());
+  return IsValidCCS(matrix_a) && IsValidCCS(matrix_b) && matrix_a.cols_count == matrix_b.rows_count;
+}
+
+bool DilshodovASpmmDoubleCssSeq::PreProcessingImpl() {
+  GetOutput() = SparseMatrixCCS{};
+  return true;
+}
+
+bool DilshodovASpmmDoubleCssSeq::RunImpl() {
+  const auto &matrix_a = std::get<0>(GetInput());
+  const auto &matrix_b = std::get<1>(GetInput());
+  auto &matrix_c = GetOutput();
+
+  matrix_c.rows_count = matrix_a.rows_count;
+  matrix_c.cols_count = matrix_b.cols_count;
+  matrix_c.col_ptrs.assign(static_cast<size_t>(matrix_c.cols_count) + 1, 0);
+  matrix_c.row_indices.clear();
+  matrix_c.values.clear();
+
+  for (int col_b = 0; col_b < matrix_b.cols_count; ++col_b) {
+    std::map<int, double> accumulator;
+
+    for (int idx_b = matrix_b.col_ptrs[col_b]; idx_b < matrix_b.col_ptrs[col_b + 1]; ++idx_b) {
+      const int pivot_row = matrix_b.row_indices[idx_b];
+      const double pivot_value = matrix_b.values[idx_b];
+
+      for (int idx_a = matrix_a.col_ptrs[pivot_row]; idx_a < matrix_a.col_ptrs[pivot_row + 1]; ++idx_a) {
+        const int result_row = matrix_a.row_indices[idx_a];
+        accumulator[result_row] += matrix_a.values[idx_a] * pivot_value;
+      }
+    }
+
+    for (const auto &[row, value] : accumulator) {
+      if (std::abs(value) > kEps) {
+        matrix_c.row_indices.push_back(row);
+        matrix_c.values.push_back(value);
+      }
+    }
+
+    matrix_c.col_ptrs[col_b + 1] = static_cast<int>(matrix_c.values.size());
+  }
+
+  matrix_c.non_zeros = static_cast<int>(matrix_c.values.size());
+  return true;
+}
+
+bool DilshodovASpmmDoubleCssSeq::PostProcessingImpl() {
+  GetOutput().non_zeros = static_cast<int>(GetOutput().values.size());
+  return true;
+}
+
+}  // namespace dilshodov_a_spmm_double_css

--- a/tasks/dilshodov_a_spmm_double_css/settings.json
+++ b/tasks/dilshodov_a_spmm_double_css/settings.json
@@ -1,0 +1,10 @@
+{
+  "tasks": {
+    "all": "enabled",
+    "omp": "enabled",
+    "seq": "enabled",
+    "stl": "enabled",
+    "tbb": "enabled"
+  },
+  "tasks_type": "threads"
+}

--- a/tasks/dilshodov_a_spmm_double_css/tests/functional/main.cpp
+++ b/tasks/dilshodov_a_spmm_double_css/tests/functional/main.cpp
@@ -1,0 +1,133 @@
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <string>
+#include <tuple>
+#include <vector>
+
+#include "dilshodov_a_spmm_double_css/common/include/common.hpp"
+#include "dilshodov_a_spmm_double_css/seq/include/ops_seq.hpp"
+#include "util/include/func_test_util.hpp"
+#include "util/include/util.hpp"
+
+namespace dilshodov_a_spmm_double_css {
+
+namespace {
+constexpr double kEps = 1e-10;
+
+SparseMatrixCCS DenseToCCS(const DenseMatrix &dense) {
+  SparseMatrixCCS matrix;
+  matrix.rows_count = static_cast<int>(dense.size());
+  matrix.cols_count = dense.empty() ? 0 : static_cast<int>(dense[0].size());
+  matrix.col_ptrs.assign(static_cast<size_t>(matrix.cols_count) + 1, 0);
+
+  for (int col = 0; col < matrix.cols_count; ++col) {
+    for (int row = 0; row < matrix.rows_count; ++row) {
+      if (std::abs(dense[row][col]) > kEps) {
+        matrix.row_indices.push_back(row);
+        matrix.values.push_back(dense[row][col]);
+      }
+    }
+    matrix.col_ptrs[col + 1] = static_cast<int>(matrix.values.size());
+  }
+
+  matrix.non_zeros = static_cast<int>(matrix.values.size());
+  return matrix;
+}
+
+DenseMatrix DenseMul(const DenseMatrix &lhs, const DenseMatrix &rhs) {
+  const int rows = static_cast<int>(lhs.size());
+  const int common = lhs.empty() ? 0 : static_cast<int>(lhs[0].size());
+  const int cols = rhs.empty() ? 0 : static_cast<int>(rhs[0].size());
+
+  DenseMatrix result(static_cast<size_t>(rows), std::vector<double>(static_cast<size_t>(cols), 0.0));
+  for (int row = 0; row < rows; ++row) {
+    for (int pivot = 0; pivot < common; ++pivot) {
+      const double lhs_value = lhs[row][pivot];
+      if (std::abs(lhs_value) <= kEps) {
+        continue;
+      }
+      for (int col = 0; col < cols; ++col) {
+        result[row][col] += lhs_value * rhs[pivot][col];
+      }
+    }
+  }
+  return result;
+}
+
+bool CompareCCS(const SparseMatrixCCS &lhs, const SparseMatrixCCS &rhs) {
+  if (lhs.rows_count != rhs.rows_count || lhs.cols_count != rhs.cols_count || lhs.non_zeros != rhs.non_zeros) {
+    return false;
+  }
+  if (lhs.col_ptrs != rhs.col_ptrs || lhs.row_indices != rhs.row_indices || lhs.values.size() != rhs.values.size()) {
+    return false;
+  }
+
+  for (size_t i = 0; i < lhs.values.size(); ++i) {
+    if (std::abs(lhs.values[i] - rhs.values[i]) > 1e-8) {
+      return false;
+    }
+  }
+  return true;
+}
+
+}  // namespace
+
+class DilshodovASpmmDoubleCssExampleFuncTests : public ppc::util::BaseRunFuncTests<InType, OutType, TestType> {
+ public:
+  static std::string PrintTestParam(const TestType &param) {
+    return std::get<0>(param);
+  }
+
+ protected:
+  void SetUp() override {
+    const TestType test_param = std::get<static_cast<size_t>(ppc::util::GTestParamIndex::kTestParams)>(GetParam());
+    const auto &dense_a = std::get<1>(test_param);
+    const auto &dense_b = std::get<2>(test_param);
+
+    input_data_ = std::make_tuple(DenseToCCS(dense_a), DenseToCCS(dense_b));
+    expected_output_ = DenseToCCS(DenseMul(dense_a, dense_b));
+  }
+
+  bool CheckTestOutputData(OutType &output_data) final {
+    return CompareCCS(output_data, expected_output_);
+  }
+
+  InType GetTestInputData() final {
+    return input_data_;
+  }
+
+ private:
+  InType input_data_;
+  SparseMatrixCCS expected_output_;
+};
+
+namespace {
+
+TEST_P(DilshodovASpmmDoubleCssExampleFuncTests, RunExampleLikeTests) {
+  ExecuteTest(GetParam());
+}
+
+const std::array<TestType, 3> kTestParams = {
+    std::make_tuple("TwoByTwoBasic", DenseMatrix{{1.0, 0.0}, {2.0, 3.0}}, DenseMatrix{{4.0, 5.0}, {0.0, 6.0}}),
+    std::make_tuple("ThreeByThreeSparse", DenseMatrix{{0.0, 2.0, 0.0}, {1.0, 0.0, 3.0}, {0.0, 4.0, 0.0}},
+                    DenseMatrix{{7.0, 0.0, 1.0}, {0.0, 8.0, 0.0}, {2.0, 0.0, 9.0}}),
+    std::make_tuple("RectangularCheck", DenseMatrix{{1.0, -1.0, 0.0}, {0.0, 2.0, 4.0}},
+                    DenseMatrix{{3.0, 0.0}, {0.0, 5.0}, {6.0, 7.0}})};
+
+const auto kTestTasksList =
+    ppc::util::AddFuncTask<DilshodovASpmmDoubleCssSeq, InType>(kTestParams, PPC_SETTINGS_dilshodov_a_spmm_double_css);
+
+const auto kGtestValues = ppc::util::ExpandToValues(kTestTasksList);
+
+const auto kPerfTestName =
+    DilshodovASpmmDoubleCssExampleFuncTests::PrintFuncTestName<DilshodovASpmmDoubleCssExampleFuncTests>;
+
+INSTANTIATE_TEST_SUITE_P(DilshodovSpmmDoubleCssExampleFunc, DilshodovASpmmDoubleCssExampleFuncTests, kGtestValues,
+                         kPerfTestName);
+
+}  // namespace
+
+}  // namespace dilshodov_a_spmm_double_css

--- a/tasks/dilshodov_a_spmm_double_css/tests/performance/main.cpp
+++ b/tasks/dilshodov_a_spmm_double_css/tests/performance/main.cpp
@@ -1,0 +1,122 @@
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <cstddef>
+#include <tuple>
+#include <vector>
+
+#include "dilshodov_a_spmm_double_css/common/include/common.hpp"
+#include "dilshodov_a_spmm_double_css/seq/include/ops_seq.hpp"
+#include "performance/include/performance.hpp"
+#include "util/include/perf_test_util.hpp"
+
+namespace dilshodov_a_spmm_double_css {
+
+namespace {
+constexpr double kEps = 1e-10;
+
+SparseMatrixCCS DenseToCCS(const DenseMatrix &dense) {
+  SparseMatrixCCS matrix;
+  matrix.rows_count = static_cast<int>(dense.size());
+  matrix.cols_count = dense.empty() ? 0 : static_cast<int>(dense[0].size());
+  matrix.col_ptrs.assign(static_cast<size_t>(matrix.cols_count) + 1, 0);
+
+  for (int col = 0; col < matrix.cols_count; ++col) {
+    for (int row = 0; row < matrix.rows_count; ++row) {
+      const double value = dense[row][col];
+      if (std::abs(value) > kEps) {
+        matrix.row_indices.push_back(row);
+        matrix.values.push_back(value);
+      }
+    }
+    matrix.col_ptrs[col + 1] = static_cast<int>(matrix.values.size());
+  }
+
+  matrix.non_zeros = static_cast<int>(matrix.values.size());
+  return matrix;
+}
+
+DenseMatrix DenseMul(const DenseMatrix &lhs, const DenseMatrix &rhs) {
+  const int rows = static_cast<int>(lhs.size());
+  const int common = lhs.empty() ? 0 : static_cast<int>(lhs[0].size());
+  const int cols = rhs.empty() ? 0 : static_cast<int>(rhs[0].size());
+
+  DenseMatrix result(static_cast<size_t>(rows), std::vector<double>(static_cast<size_t>(cols), 0.0));
+  for (int row = 0; row < rows; ++row) {
+    for (int pivot = 0; pivot < common; ++pivot) {
+      const double lhs_value = lhs[row][pivot];
+      if (std::abs(lhs_value) <= kEps) {
+        continue;
+      }
+      for (int col = 0; col < cols; ++col) {
+        result[row][col] += lhs_value * rhs[pivot][col];
+      }
+    }
+  }
+  return result;
+}
+
+bool CompareCCS(const SparseMatrixCCS &lhs, const SparseMatrixCCS &rhs) {
+  if (lhs.rows_count != rhs.rows_count || lhs.cols_count != rhs.cols_count || lhs.non_zeros != rhs.non_zeros) {
+    return false;
+  }
+  if (lhs.col_ptrs != rhs.col_ptrs || lhs.row_indices != rhs.row_indices || lhs.values.size() != rhs.values.size()) {
+    return false;
+  }
+  for (size_t i = 0; i < lhs.values.size(); ++i) {
+    if (std::abs(lhs.values[i] - rhs.values[i]) > 1e-8) {
+      return false;
+    }
+  }
+  return true;
+}
+
+}  // namespace
+
+class DilshodovASpmmDoubleCssExamplePerfTests : public ppc::util::BaseRunPerfTests<InType, OutType> {
+ protected:
+  void SetPerfAttributes(ppc::performance::PerfAttr &perf_attr) override {
+    ppc::util::BaseRunPerfTests<InType, OutType>::SetPerfAttributes(perf_attr);
+    perf_attr.num_running = 1;
+  }
+
+  void SetUp() override {
+    DenseMatrix dense_a{{1.0, 0.0, 2.0}, {0.0, 3.0, 0.0}, {4.0, 0.0, 5.0}};
+    DenseMatrix dense_b{{0.0, 6.0, 0.0}, {7.0, 0.0, 8.0}, {0.0, 9.0, 1.0}};
+
+    input_data_ = std::make_tuple(DenseToCCS(dense_a), DenseToCCS(dense_b));
+    expected_output_ = DenseToCCS(DenseMul(dense_a, dense_b));
+  }
+
+  bool CheckTestOutputData(OutType &output_data) final {
+    return CompareCCS(output_data, expected_output_);
+  }
+
+  InType GetTestInputData() final {
+    return input_data_;
+  }
+
+ private:
+  InType input_data_;
+  OutType expected_output_;
+};
+
+TEST_P(DilshodovASpmmDoubleCssExamplePerfTests, RunPerfModes) {
+  ExecuteTest(GetParam());
+}
+
+namespace {
+
+const auto kAllPerfTasks =
+    ppc::util::MakeAllPerfTasks<InType, DilshodovASpmmDoubleCssSeq>(PPC_SETTINGS_dilshodov_a_spmm_double_css);
+
+const auto kGtestValues = ppc::util::TupleToGTestValues(kAllPerfTasks);
+
+const auto kPerfTestName = DilshodovASpmmDoubleCssExamplePerfTests::CustomPerfTestName;
+
+INSTANTIATE_TEST_SUITE_P(DilshodovSpmmDoubleCssExamplePerf, DilshodovASpmmDoubleCssExamplePerfTests, kGtestValues,
+                         kPerfTestName);
+
+}  // namespace
+
+}  // namespace dilshodov_a_spmm_double_css


### PR DESCRIPTION
<!--
Требования к названию pull request:

"<Фамилия> <Имя>. Технология <TECHNOLOGY_NAME:SEQ|OMP|TBB|STL|MPI>. <Полное название задачи>. Вариант <Номер>"
-->

## Описание
<!--
Пожалуйста, предоставьте подробное описание вашей реализации, включая:
 - основные детали решения (описание выбранного алгоритма)
 - применение технологии параллелизма (если применимо)
-->

- **Задача**: Умножение разреженных матриц. Элементы типа double. Формат хранения матрицы – столбцовый (CCS).
- **Вариант**:5
- **Технология**: SEQ
- **Описание** вашей реализации и отчёта.  
Реализована последовательная версия умножения разреженных матриц double в формате CCS: входные матрицы проверяются на корректность структуры и согласованность размеров, после чего по столбцам выполняется накопление произведений в промежуточный контейнер и формируется результат тоже в CCS.

---

## Чек-лист
<!--
Пожалуйста, убедитесь, что следующие пункты выполнены **до** отправки pull request'а и запроса его ревью:
-->

- [x] **Статус CI**: Все CI-задачи (сборка, тесты, генерация отчёта) успешно проходят на моей ветке в моем форке
- [x] **Директория и именование задачи**: Я создал директорию с именем `<фамилия>_<первая_буква_имени>_<короткое_название_задачи>`
- [x] **Полное описание задачи**: Я предоставил полное описание задачи в теле pull request
- [x] **clang-format**: Мои изменения успешно проходят `clang-format` локально в моем форке (нет ошибок форматирования)
- [x] **clang-tidy**: Мои изменения успешно проходят `clang-tidy` локально в моем форке (нет предупреждений/ошибок)
- [x] **Функциональные тесты**: Все функциональные тесты успешно проходят локально на моей машине
- [x] **Тесты производительности**: Все тесты производительности успешно проходят локально на моей машине
- [x] **Ветка**: Я работаю в ветке, названной точно так же, как директория моей задачи
  (например, `nesterov_a_vector_sum`), а не в `master`
- [x] **Правдивое содержание**: Я подтверждаю, что все сведения, указанные в этом pull request, являются точными и
  достоверными

<!--
ПРИМЕЧАНИЕ: Ложные сведения в этом чек-листе могут привести к отклонению PR и получению нулевого балла
за соответствующую задачу.
-->
