### PR TITLE
Вотинцев Дмитрий. Технология TBB. Поразрядная сортировка для целых чисел с простым слиянием. Вариант 17.

### DIFF
--- a/tasks/votincev_d_radixmerge_sort/omp/include/ops_omp.hpp
+++ b/tasks/votincev_d_radixmerge_sort/omp/include/ops_omp.hpp
@@ -24,5 +24,7 @@ class VotincevDRadixMergeSortOMP : public BaseTask {
   // ==============================
   // мои дополнительные функции ===
   static void SortByDigit(std::vector<int32_t> &array, int32_t exp);
+  static void LocalRadixSort(uint32_t *begin, uint32_t *end);
+  static void Merge(const uint32_t *src, uint32_t *dst, int32_t left, int32_t mid, int32_t right);
 };
 }  // namespace votincev_d_radixmerge_sort

--- a/tasks/votincev_d_radixmerge_sort/omp/src/ops_omp.cpp
+++ b/tasks/votincev_d_radixmerge_sort/omp/src/ops_omp.cpp
@@ -3,8 +3,10 @@
 #include <omp.h>
 
 #include <algorithm>
+#include <array>
 #include <cstddef>
 #include <cstdint>
+#include <utility>
 #include <vector>
 
 #include "votincev_d_radixmerge_sort/common/include/common.hpp"
@@ -24,63 +26,112 @@ bool VotincevDRadixMergeSortOMP::PreProcessingImpl() {
   return true;
 }
 
-void VotincevDRadixMergeSortOMP::SortByDigit(std::vector<int32_t> &array, int32_t exp) {
-  std::vector<std::vector<int32_t>> buckets(10);
-
-  for (const auto &num : array) {
-    int32_t digit = (num / exp) % 10;
-    buckets[digit].push_back(num);
+void VotincevDRadixMergeSortOMP::LocalRadixSort(uint32_t *begin, uint32_t *end) {
+  auto n = static_cast<int32_t>(end - begin);
+  if (n <= 1) {
+    return;
   }
 
-  size_t index = 0;
-  for (int i = 0; i < 10; ++i) {
-    for (const auto &val : buckets[i]) {
-      array[index++] = val;
+  uint32_t max_val = *std::max_element(begin, end);
+
+  std::vector<uint32_t> buffer(static_cast<size_t>(n));
+  uint32_t *src = begin;
+  uint32_t *dst = buffer.data();
+
+  for (int64_t exp = 1; (static_cast<int64_t>(max_val) / exp) > 0; exp *= 10) {
+    std::array<int32_t, 10> count{};
+
+    for (int32_t i = 0; i < n; ++i) {
+      count.at(static_cast<size_t>((src[i] / exp) % 10))++;
     }
-    buckets[i].clear();
+    for (int32_t i = 1; i < 10; ++i) {
+      count.at(static_cast<size_t>(i)) += count.at(static_cast<size_t>(i - 1));
+    }
+    for (int32_t i = n - 1; i >= 0; --i) {
+      auto digit = static_cast<size_t>((src[i] / exp) % 10);
+
+      size_t target_idx = static_cast<size_t>(count.at(digit)) - 1;
+      dst[target_idx] = src[i];
+
+      count.at(digit)--;
+    }
+    std::swap(src, dst);
+  }
+
+  if (src != begin) {
+    std::copy(src, src + n, begin);
+  }
+}
+
+void VotincevDRadixMergeSortOMP::Merge(const uint32_t *src, uint32_t *dst, int32_t left, int32_t mid, int32_t right) {
+  int32_t i = left;
+  int32_t j = mid;
+  int32_t k = left;
+  while (i < mid && j < right) {
+    dst[k++] = (src[i] <= src[j]) ? src[i++] : src[j++];
+  }
+  while (i < mid) {
+    dst[k++] = src[i++];
+  }
+  while (j < right) {
+    dst[k++] = src[j++];
   }
 }
 
 bool VotincevDRadixMergeSortOMP::RunImpl() {
-  if (GetInput().empty()) {
-    return false;
-  }
+  const auto &input = GetInput();
+  auto n = static_cast<int32_t>(input.size());
 
-  std::vector<int32_t> working_array = GetInput();
-  auto n = static_cast<int32_t>(working_array.size());
+  std::vector<uint32_t> working_array(static_cast<size_t>(n));
+  int32_t min_val = input[0];
 
-  int32_t min_val = working_array[0];
-#pragma omp parallel for reduction(min : min_val) default(none) shared(working_array, n)
+#pragma omp parallel for reduction(min : min_val) default(none) shared(n, input)
   for (int32_t i = 0; i < n; ++i) {
-    min_val = std::min(min_val, working_array[i]);
+    min_val = std::min(input[i], min_val);
   }
 
-  if (min_val < 0) {
-#pragma omp parallel for default(none) shared(working_array, n, min_val)
-    for (int32_t i = 0; i < n; ++i) {
-      working_array[i] -= min_val;
+#pragma omp parallel for default(none) shared(n, working_array, input, min_val)
+  for (int32_t i = 0; i < n; ++i) {
+    working_array[static_cast<size_t>(i)] = static_cast<uint32_t>(input[i]) - static_cast<uint32_t>(min_val);
+  }
+
+  std::vector<uint32_t> temp_buffer(static_cast<size_t>(n));
+
+#pragma omp parallel default(none) shared(n, working_array, temp_buffer)
+  {
+    int tid = omp_get_thread_num();
+    int n_threads = omp_get_num_threads();
+
+    int32_t items = n / n_threads;
+    int32_t rem = n % n_threads;
+    int32_t l = (tid * items) + std::min(tid, rem);
+    int32_t r = l + items + (tid < rem ? 1 : 0);
+
+    if (l < r) {
+      LocalRadixSort(working_array.data() + l, working_array.data() + r);
+    }
+
+    for (int32_t step = 1; step < n_threads; step *= 2) {
+#pragma omp barrier
+      if ((tid % (2 * step) == 0) && (tid + step < n_threads)) {
+        int32_t m = ((tid + step) * items) + std::min(tid + step, rem);
+        int32_t next_tid = std::min(tid + (2 * step), n_threads);
+        int32_t next_r = (next_tid * items) + std::min(next_tid, rem);
+
+        Merge(working_array.data(), temp_buffer.data(), l, m, next_r);
+        std::copy(temp_buffer.data() + l, temp_buffer.data() + next_r, working_array.data() + l);
+      }
     }
   }
 
-  int32_t max_val = working_array[0];
-#pragma omp parallel for reduction(max : max_val) default(none) shared(working_array, n)
+  std::vector<int32_t> result(static_cast<size_t>(n));
+#pragma omp parallel for default(none) shared(n, result, working_array, min_val)
   for (int32_t i = 0; i < n; ++i) {
-    max_val = std::max(max_val, working_array[i]);
+    result[static_cast<size_t>(i)] =
+        static_cast<int32_t>(working_array[static_cast<size_t>(i)] + static_cast<uint32_t>(min_val));
   }
 
-  for (int32_t exp = 1; max_val / exp > 0; exp *= 10) {
-    SortByDigit(working_array, exp);
-  }
-
-  if (min_val < 0) {
-#pragma omp parallel for default(none) shared(working_array, n, min_val)
-    for (int32_t i = 0; i < n; ++i) {
-      working_array[i] += min_val;
-    }
-  }
-
-  GetOutput() = working_array;
-
+  GetOutput() = std::move(result);
   return true;
 }
 

--- a/tasks/votincev_d_radixmerge_sort/seq/src/ops_seq.cpp
+++ b/tasks/votincev_d_radixmerge_sort/seq/src/ops_seq.cpp
@@ -1,8 +1,10 @@
 #include "votincev_d_radixmerge_sort/seq/include/ops_seq.hpp"
 
 #include <algorithm>
+#include <array>
 #include <cstddef>
 #include <cstdint>
+#include <utility>
 #include <vector>
 
 #include "votincev_d_radixmerge_sort/common/include/common.hpp"
@@ -14,78 +16,73 @@ VotincevDRadixMergeSortSEQ::VotincevDRadixMergeSortSEQ(const InType &in) {
   GetInput() = in;
 }
 
-// проверка входных данных
 bool VotincevDRadixMergeSortSEQ::ValidationImpl() {
-  // проверка: входной вектор не должен быть пустым
   return !GetInput().empty();
 }
 
-// препроцессинг
 bool VotincevDRadixMergeSortSEQ::PreProcessingImpl() {
   return true;
 }
 
-// вспомогательный метод для распределения и слияния разрядов
+// поразрядная сортировка
 void VotincevDRadixMergeSortSEQ::SortByDigit(std::vector<int32_t> &array, int32_t exp) {
-  std::vector<std::vector<int32_t>> buckets(10);
+  size_t n = array.size();
+  std::vector<int32_t> output(n);
+  std::array<int32_t, 10> count{};
 
-  // распределение элементов по корзинам
-  for (const auto &num : array) {
-    int32_t digit = (num / exp) % 10;
-    buckets[digit].push_back(num);
+  for (size_t i = 0; i < n; i++) {
+    int32_t digit = (array[i] / exp) % 10;
+    count.at(static_cast<size_t>(digit))++;
   }
 
-  // простое слияние корзин обратно в рабочий массив
-  size_t index = 0;
-  for (int i = 0; i < 10; ++i) {
-    for (const auto &val : buckets[i]) {
-      array[index++] = val;
-    }
-    // очистка корзины для следующего разряда
-    buckets[i].clear();
+  // префиксные суммы
+  for (size_t i = 1; i < 10; i++) {
+    count.at(i) += count.at(i - 1);
   }
+
+  // формирую выходной массив
+  for (int64_t i = static_cast<int64_t>(n) - 1; i >= 0; i--) {
+    auto idx = static_cast<size_t>(i);
+    auto digit = static_cast<size_t>((array.at(idx) / exp) % 10);
+    size_t pos = static_cast<size_t>(count.at(digit)) - 1;
+    output.at(pos) = array.at(idx);
+    count.at(digit)--;
+  }
+
+  array = std::move(output);
 }
 
-// основной метод алгоритма
 bool VotincevDRadixMergeSortSEQ::RunImpl() {
-  if (GetInput().empty()) {
-    return false;
-  }
-
-  // локальная копия данных для сортировки
   std::vector<int32_t> working_array = GetInput();
 
-  // обработка отрицательных чисел
-  int32_t min_val = *std::ranges::min_element(working_array);
+  auto [min_it, max_it] = std::ranges::minmax_element(working_array);
+  int32_t min_val = *min_it;
+  int32_t max_val = *max_it;
 
+  // сдвиг в положительную область
   if (min_val < 0) {
     for (auto &num : working_array) {
       num -= min_val;
     }
+    max_val -= min_val;
   }
 
-  // ищем максимальное число для определения количества разрядов
-  int32_t max_val = *std::ranges::max_element(working_array);
-
-  // цикл по разрядам (единицы, десятки, сотни...)
-  for (int32_t exp = 1; max_val / exp > 0; exp *= 10) {
-    SortByDigit(working_array, exp);
+  // цикл по разрядам
+  for (int64_t exp = 1; static_cast<int64_t>(max_val) / exp > 0; exp *= 10) {
+    SortByDigit(working_array, static_cast<int32_t>(exp));
   }
 
-  // возвращаем значения к исходному диапазону
+  // возврат к исходному диапазону
   if (min_val < 0) {
     for (auto &num : working_array) {
       num += min_val;
     }
   }
 
-  // запись результата в выходные данные
-  GetOutput() = working_array;
-
+  GetOutput() = std::move(working_array);
   return true;
 }
 
-// постпроцессинг
 bool VotincevDRadixMergeSortSEQ::PostProcessingImpl() {
   return true;
 }

--- a/tasks/votincev_d_radixmerge_sort/tbb/include/ops_tbb.hpp
+++ b/tasks/votincev_d_radixmerge_sort/tbb/include/ops_tbb.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <cstdint>
-#include <vector>
 
 #include "task/include/task.hpp"
 #include "votincev_d_radixmerge_sort/common/include/common.hpp"

--- a/tasks/votincev_d_radixmerge_sort/tbb/include/ops_tbb.hpp
+++ b/tasks/votincev_d_radixmerge_sort/tbb/include/ops_tbb.hpp
@@ -23,7 +23,7 @@ class VotincevDRadixMergeSortTBB : public BaseTask {
   // ==============================
   // мои дополнительные функции ===
   static void LocalRadixSort(uint32_t *begin, uint32_t *end);
-  static void Merge(uint32_t *data, int32_t left, int32_t mid, int32_t right, uint32_t *temp);
+  static void Merge(const uint32_t *src, uint32_t *dst, int32_t left, int32_t mid, int32_t right);
   static void ParallelRadixMergeSort(uint32_t *data, int32_t left, int32_t right, uint32_t *temp);
 };
 }  // namespace votincev_d_radixmerge_sort

--- a/tasks/votincev_d_radixmerge_sort/tbb/include/ops_tbb.hpp
+++ b/tasks/votincev_d_radixmerge_sort/tbb/include/ops_tbb.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+#include "task/include/task.hpp"
+#include "votincev_d_radixmerge_sort/common/include/common.hpp"
+
+namespace votincev_d_radixmerge_sort {
+
+class VotincevDRadixMergeSortTBB : public BaseTask {
+ public:
+  static constexpr ppc::task::TypeOfTask GetStaticTypeOfTask() {
+    return ppc::task::TypeOfTask::kTBB;
+  }
+  explicit VotincevDRadixMergeSortTBB(const InType &in);
+
+ private:
+  bool ValidationImpl() override;
+  bool PreProcessingImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+
+  // ==============================
+  // мои дополнительные функции ===
+  static void LocalRadixSort(uint32_t *begin, uint32_t *end);
+  static void Merge(uint32_t *data, int32_t left, int32_t mid, int32_t right, uint32_t *temp);
+  static void ParallelRadixMergeSort(uint32_t *data, int32_t left, int32_t right, uint32_t *temp);
+};
+}  // namespace votincev_d_radixmerge_sort

--- a/tasks/votincev_d_radixmerge_sort/tbb/src/ops_tbb.cpp
+++ b/tasks/votincev_d_radixmerge_sort/tbb/src/ops_tbb.cpp
@@ -1,0 +1,137 @@
+#include "votincev_d_radixmerge_sort/tbb/include/ops_tbb.hpp"
+
+#include <tbb/tbb.h>
+
+#include <algorithm>
+#include <vector>
+
+#include "votincev_d_radixmerge_sort/common/include/common.hpp"
+
+namespace votincev_d_radixmerge_sort {
+
+VotincevDRadixMergeSortTBB::VotincevDRadixMergeSortTBB(const InType &in) {
+  SetTypeOfTask(GetStaticTypeOfTask());
+  GetInput() = in;
+}
+
+bool VotincevDRadixMergeSortTBB::ValidationImpl() {
+  return !GetInput().empty();
+}
+
+bool VotincevDRadixMergeSortTBB::PreProcessingImpl() {
+  return true;
+}
+
+// поразрядная сортировка для локальных блоков
+void VotincevDRadixMergeSortTBB::LocalRadixSort(uint32_t *begin, uint32_t *end) {
+  int32_t n = static_cast<int32_t>(end - begin);
+  if (n <= 1) {
+    return;
+  }
+
+  uint32_t max_val = begin[0];
+  for (int32_t i = 1; i < n; ++i) {
+    if (begin[i] > max_val) {
+      max_val = begin[i];
+    }
+  }
+
+  std::vector<uint32_t> buffer(n);
+  uint32_t *src = begin;
+  uint32_t *dst = buffer.data();
+
+  //  int64_t для exp, чтобы избежать переполнения при exp * 10
+  for (int64_t exp = 1; static_cast<int64_t>(max_val) / exp > 0; exp *= 10) {
+    int32_t count[10] = {0};
+
+    for (int32_t i = 0; i < n; ++i) {
+      count[(src[i] / exp) % 10]++;
+    }
+    for (int32_t i = 1; i < 10; ++i) {
+      count[i] += count[i - 1];
+    }
+    for (int32_t i = n - 1; i >= 0; --i) {
+      uint32_t digit = (src[i] / exp) % 10;
+      dst[--count[digit]] = src[i];
+    }
+    std::swap(src, dst);
+  }
+
+  if (src != begin) {
+    std::copy(src, src + n, begin);
+  }
+}
+
+// слияние двух отсортированных участков
+void VotincevDRadixMergeSortTBB::Merge(uint32_t *data, int32_t left, int32_t mid, int32_t right, uint32_t *temp) {
+  int32_t i = left, j = mid, k = left;
+  while (i < mid && j < right) {
+    temp[k++] = (data[i] <= data[j]) ? data[i++] : data[j++];
+  }
+  while (i < mid) {
+    temp[k++] = data[i++];
+  }
+  while (j < right) {
+    temp[k++] = data[j++];
+  }
+
+  std::copy(temp + left, temp + right, data + left);
+}
+
+// параллельная сортировка слиянием(сортировка + слияние)
+void VotincevDRadixMergeSortTBB::ParallelRadixMergeSort(uint32_t *data, int32_t left, int32_t right, uint32_t *temp) {
+  const int32_t GRAIN_SIZE = 4096;  // порог для перехода на последовательную сортировку
+
+  if (right - left <= GRAIN_SIZE) {
+    LocalRadixSort(data + left, data + right);
+    return;
+  }
+
+  int32_t mid = left + (right - left) / 2;
+
+  // рекурсивно запускаются две задачи в параллель
+  tbb::parallel_invoke([&] { ParallelRadixMergeSort(data, left, mid, temp); },
+                       [&] { ParallelRadixMergeSort(data, mid, right, temp); });
+
+  // слияние результатов
+  Merge(data, left, mid, right, temp);
+}
+
+bool VotincevDRadixMergeSortTBB::RunImpl() {
+  const auto &input = GetInput();
+  int32_t n = static_cast<int32_t>(input.size());
+
+  // поиск минимума
+  int32_t min_val = tbb::parallel_reduce(tbb::blocked_range<int32_t>(0, n), input[0],
+                                         [&](const tbb::blocked_range<int32_t> &r, int32_t local_min) {
+    for (int32_t i = r.begin(); i < r.end(); ++i) {
+      if (input[i] < local_min) {
+        local_min = input[i];
+      }
+    }
+    return local_min;
+  }, [](int32_t a, int32_t b) { return std::min(a, b); });
+
+  // приведение к положительным uint32
+  std::vector<uint32_t> working_array(n);
+  tbb::parallel_for(
+      0, n, [&](int32_t i) { working_array[i] = static_cast<uint32_t>(input[i]) - static_cast<uint32_t>(min_val); });
+
+  // параллельная сортировка со слиянием
+  std::vector<uint32_t> temp_buffer(n);
+  ParallelRadixMergeSort(working_array.data(), 0, n, temp_buffer.data());
+
+  // восстановление исходных значений
+  std::vector<int32_t> result(n);
+  tbb::parallel_for(
+      0, n, [&](int32_t i) { result[i] = static_cast<int32_t>(working_array[i] + static_cast<uint32_t>(min_val)); });
+
+  GetOutput() = std::move(result);
+  return true;
+}
+
+bool VotincevDRadixMergeSortTBB::PostProcessingImpl() {
+  return true;
+}
+
+}  // namespace votincev_d_radixmerge_sort

--- a/tasks/votincev_d_radixmerge_sort/tbb/src/ops_tbb.cpp
+++ b/tasks/votincev_d_radixmerge_sort/tbb/src/ops_tbb.cpp
@@ -26,34 +26,31 @@ bool VotincevDRadixMergeSortTBB::PreProcessingImpl() {
 }
 
 // поразрядная сортировка для локальных блоков
-void VotincevDRadixMergeSortTBB::LocalRadixSort(uint32_t *begin, uint32_t *end) {
+void VotincevDRadixMergeSortOMP::LocalRadixSort(uint32_t *begin, uint32_t *end) {
   auto n = static_cast<int32_t>(end - begin);
   if (n <= 1) {
     return;
   }
 
-  uint32_t max_val = begin[0];
-  for (int32_t i = 1; i < n; ++i) {
-    max_val = std::max(begin[static_cast<size_t>(i)], max_val);
-  }
+  uint32_t max_val = *std::max_element(begin, end);
 
   std::vector<uint32_t> buffer(static_cast<size_t>(n));
   uint32_t *src = begin;
   uint32_t *dst = buffer.data();
 
-  //  int64_t для exp, чтобы избежать переполнения при exp * 10
   for (int64_t exp = 1; (static_cast<int64_t>(max_val) / exp) > 0; exp *= 10) {
     std::array<int32_t, 10> count{};
 
     for (int32_t i = 0; i < n; ++i) {
-      count[static_cast<size_t>((src[static_cast<size_t>(i)] / exp) % 10)]++;
+      count.at(static_cast<size_t>((src[i] / exp) % 10))++;
     }
     for (int32_t i = 1; i < 10; ++i) {
-      count[static_cast<size_t>(i)] += count[static_cast<size_t>(i - 1)];
+      count.at(static_cast<size_t>(i)) += count.at(static_cast<size_t>(i - 1));
     }
     for (int32_t i = n - 1; i >= 0; --i) {
-      uint32_t digit = (src[static_cast<size_t>(i)] / exp) % 10;
-      dst[--count[static_cast<size_t>(digit)]] = src[static_cast<size_t>(i)];
+      uint32_t digit = (src[i] / exp) % 10;
+      dst.at(count.at(static_cast<size_t>(digit))) = src[i];
+      count.at(static_cast<size_t>(digit))--;
     }
     std::swap(src, dst);
   }
@@ -64,23 +61,19 @@ void VotincevDRadixMergeSortTBB::LocalRadixSort(uint32_t *begin, uint32_t *end) 
 }
 
 // слияние двух отсортированных участков
-void VotincevDRadixMergeSortTBB::Merge(uint32_t *data, int32_t left, int32_t mid, int32_t right, uint32_t *temp) {
+void VotincevDRadixMergeSortOMP::Merge(const uint32_t *src, uint32_t *dst, int32_t left, int32_t mid, int32_t right) {
   int32_t i = left;
   int32_t j = mid;
   int32_t k = left;
   while (i < mid && j < right) {
-    temp[static_cast<size_t>(k++)] = (data[static_cast<size_t>(i)] <= data[static_cast<size_t>(j)])
-                                         ? data[static_cast<size_t>(i++)]
-                                         : data[static_cast<size_t>(j++)];
+    dst[k++] = (src[i] <= src[j]) ? src[i++] : src[j++];
   }
   while (i < mid) {
-    temp[static_cast<size_t>(k++)] = data[static_cast<size_t>(i++)];
+    dst[k++] = src[i++];
   }
   while (j < right) {
-    temp[static_cast<size_t>(k++)] = data[static_cast<size_t>(j++)];
+    dst[k++] = src[j++];
   }
-
-  std::copy(temp + left, temp + right, data + left);
 }
 
 // параллельная сортировка слиянием(сортировка + слияние)

--- a/tasks/votincev_d_radixmerge_sort/tbb/src/ops_tbb.cpp
+++ b/tasks/votincev_d_radixmerge_sort/tbb/src/ops_tbb.cpp
@@ -26,7 +26,7 @@ bool VotincevDRadixMergeSortTBB::PreProcessingImpl() {
 }
 
 // поразрядная сортировка для локальных блоков
-void VotincevDRadixMergeSortTBB::LocalRadixSort(uint32_t *begin, const uint32_t *end) {
+void VotincevDRadixMergeSortTBB::LocalRadixSort(uint32_t *begin, uint32_t *end) {
   auto n = static_cast<int32_t>(end - begin);
   if (n <= 1) {
     return;

--- a/tasks/votincev_d_radixmerge_sort/tbb/src/ops_tbb.cpp
+++ b/tasks/votincev_d_radixmerge_sort/tbb/src/ops_tbb.cpp
@@ -3,6 +3,9 @@
 #include <tbb/tbb.h>
 
 #include <algorithm>
+#include <array>
+#include <cstdint>
+#include <utility>
 #include <vector>
 
 #include "votincev_d_radixmerge_sort/common/include/common.hpp"
@@ -23,36 +26,34 @@ bool VotincevDRadixMergeSortTBB::PreProcessingImpl() {
 }
 
 // поразрядная сортировка для локальных блоков
-void VotincevDRadixMergeSortTBB::LocalRadixSort(uint32_t *begin, uint32_t *end) {
-  int32_t n = static_cast<int32_t>(end - begin);
+void VotincevDRadixMergeSortTBB::LocalRadixSort(uint32_t *begin, const uint32_t *end) {
+  auto n = static_cast<int32_t>(end - begin);
   if (n <= 1) {
     return;
   }
 
   uint32_t max_val = begin[0];
   for (int32_t i = 1; i < n; ++i) {
-    if (begin[i] > max_val) {
-      max_val = begin[i];
-    }
+    max_val = std::max(begin[static_cast<size_t>(i)], max_val);
   }
 
-  std::vector<uint32_t> buffer(n);
+  std::vector<uint32_t> buffer(static_cast<size_t>(n));
   uint32_t *src = begin;
   uint32_t *dst = buffer.data();
 
   //  int64_t для exp, чтобы избежать переполнения при exp * 10
-  for (int64_t exp = 1; static_cast<int64_t>(max_val) / exp > 0; exp *= 10) {
-    int32_t count[10] = {0};
+  for (int64_t exp = 1; (static_cast<int64_t>(max_val) / exp) > 0; exp *= 10) {
+    std::array<int32_t, 10> count{};
 
     for (int32_t i = 0; i < n; ++i) {
-      count[(src[i] / exp) % 10]++;
+      count[static_cast<size_t>((src[static_cast<size_t>(i)] / exp) % 10)]++;
     }
     for (int32_t i = 1; i < 10; ++i) {
-      count[i] += count[i - 1];
+      count[static_cast<size_t>(i)] += count[static_cast<size_t>(i - 1)];
     }
     for (int32_t i = n - 1; i >= 0; --i) {
-      uint32_t digit = (src[i] / exp) % 10;
-      dst[--count[digit]] = src[i];
+      uint32_t digit = (src[static_cast<size_t>(i)] / exp) % 10;
+      dst[--count[static_cast<size_t>(digit)]] = src[static_cast<size_t>(i)];
     }
     std::swap(src, dst);
   }
@@ -64,15 +65,19 @@ void VotincevDRadixMergeSortTBB::LocalRadixSort(uint32_t *begin, uint32_t *end) 
 
 // слияние двух отсортированных участков
 void VotincevDRadixMergeSortTBB::Merge(uint32_t *data, int32_t left, int32_t mid, int32_t right, uint32_t *temp) {
-  int32_t i = left, j = mid, k = left;
+  int32_t i = left;
+  int32_t j = mid;
+  int32_t k = left;
   while (i < mid && j < right) {
-    temp[k++] = (data[i] <= data[j]) ? data[i++] : data[j++];
+    temp[static_cast<size_t>(k++)] = (data[static_cast<size_t>(i)] <= data[static_cast<size_t>(j)])
+                                         ? data[static_cast<size_t>(i++)]
+                                         : data[static_cast<size_t>(j++)];
   }
   while (i < mid) {
-    temp[k++] = data[i++];
+    temp[static_cast<size_t>(k++)] = data[static_cast<size_t>(i++)];
   }
   while (j < right) {
-    temp[k++] = data[j++];
+    temp[static_cast<size_t>(k++)] = data[static_cast<size_t>(j++)];
   }
 
   std::copy(temp + left, temp + right, data + left);
@@ -80,14 +85,14 @@ void VotincevDRadixMergeSortTBB::Merge(uint32_t *data, int32_t left, int32_t mid
 
 // параллельная сортировка слиянием(сортировка + слияние)
 void VotincevDRadixMergeSortTBB::ParallelRadixMergeSort(uint32_t *data, int32_t left, int32_t right, uint32_t *temp) {
-  const int32_t GRAIN_SIZE = 4096;  // порог для перехода на последовательную сортировку
+  const int32_t grain_size = 4096;  // порог для перехода на последовательную сортировку
 
-  if (right - left <= GRAIN_SIZE) {
+  if (right - left <= grain_size) {
     LocalRadixSort(data + left, data + right);
     return;
   }
 
-  int32_t mid = left + (right - left) / 2;
+  int32_t mid = left + ((right - left) / 2);
 
   // рекурсивно запускаются две задачи в параллель
   tbb::parallel_invoke([&] { ParallelRadixMergeSort(data, left, mid, temp); },
@@ -99,32 +104,34 @@ void VotincevDRadixMergeSortTBB::ParallelRadixMergeSort(uint32_t *data, int32_t 
 
 bool VotincevDRadixMergeSortTBB::RunImpl() {
   const auto &input = GetInput();
-  int32_t n = static_cast<int32_t>(input.size());
+  auto n = static_cast<int32_t>(input.size());
 
   // поиск минимума
   int32_t min_val = tbb::parallel_reduce(tbb::blocked_range<int32_t>(0, n), input[0],
                                          [&](const tbb::blocked_range<int32_t> &r, int32_t local_min) {
     for (int32_t i = r.begin(); i < r.end(); ++i) {
-      if (input[i] < local_min) {
-        local_min = input[i];
-      }
+      local_min = std::min(input[static_cast<size_t>(i)], local_min);
     }
     return local_min;
   }, [](int32_t a, int32_t b) { return std::min(a, b); });
 
   // приведение к положительным uint32
-  std::vector<uint32_t> working_array(n);
-  tbb::parallel_for(
-      0, n, [&](int32_t i) { working_array[i] = static_cast<uint32_t>(input[i]) - static_cast<uint32_t>(min_val); });
+  std::vector<uint32_t> working_array(static_cast<size_t>(n));
+  tbb::parallel_for(0, n, [&](int32_t i) {
+    working_array[static_cast<size_t>(i)] =
+        static_cast<uint32_t>(input[static_cast<size_t>(i)]) - static_cast<uint32_t>(min_val);
+  });
 
   // параллельная сортировка со слиянием
-  std::vector<uint32_t> temp_buffer(n);
+  std::vector<uint32_t> temp_buffer(static_cast<size_t>(n));
   ParallelRadixMergeSort(working_array.data(), 0, n, temp_buffer.data());
 
   // восстановление исходных значений
-  std::vector<int32_t> result(n);
-  tbb::parallel_for(
-      0, n, [&](int32_t i) { result[i] = static_cast<int32_t>(working_array[i] + static_cast<uint32_t>(min_val)); });
+  std::vector<int32_t> result(static_cast<size_t>(n));
+  tbb::parallel_for(0, n, [&](int32_t i) {
+    result[static_cast<size_t>(i)] =
+        static_cast<int32_t>(working_array[static_cast<size_t>(i)] + static_cast<uint32_t>(min_val));
+  });
 
   GetOutput() = std::move(result);
   return true;

--- a/tasks/votincev_d_radixmerge_sort/tbb/src/ops_tbb.cpp
+++ b/tasks/votincev_d_radixmerge_sort/tbb/src/ops_tbb.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cstddef>
 #include <cstdint>
 #include <utility>
 #include <vector>
@@ -48,7 +49,7 @@ void VotincevDRadixMergeSortTBB::LocalRadixSort(uint32_t *begin, uint32_t *end) 
       count.at(static_cast<size_t>(i)) += count.at(static_cast<size_t>(i - 1));
     }
     for (int32_t i = n - 1; i >= 0; --i) {
-      size_t digit = static_cast<size_t>((src[i] / exp) % 10);
+      auto digit = static_cast<size_t>((src[i] / exp) % 10);
 
       size_t target_idx = static_cast<size_t>(count.at(digit)) - 1;
       dst[target_idx] = src[i];

--- a/tasks/votincev_d_radixmerge_sort/tbb/src/ops_tbb.cpp
+++ b/tasks/votincev_d_radixmerge_sort/tbb/src/ops_tbb.cpp
@@ -26,7 +26,7 @@ bool VotincevDRadixMergeSortTBB::PreProcessingImpl() {
 }
 
 // поразрядная сортировка для локальных блоков
-void VotincevDRadixMergeSortOMP::LocalRadixSort(uint32_t *begin, uint32_t *end) {
+void VotincevDRadixMergeSortTBB::LocalRadixSort(uint32_t *begin, uint32_t *end) {
   auto n = static_cast<int32_t>(end - begin);
   if (n <= 1) {
     return;
@@ -48,9 +48,12 @@ void VotincevDRadixMergeSortOMP::LocalRadixSort(uint32_t *begin, uint32_t *end) 
       count.at(static_cast<size_t>(i)) += count.at(static_cast<size_t>(i - 1));
     }
     for (int32_t i = n - 1; i >= 0; --i) {
-      uint32_t digit = (src[i] / exp) % 10;
-      dst.at(count.at(static_cast<size_t>(digit))) = src[i];
-      count.at(static_cast<size_t>(digit))--;
+      size_t digit = static_cast<size_t>((src[i] / exp) % 10);
+
+      size_t target_idx = static_cast<size_t>(count.at(digit)) - 1;
+      dst[target_idx] = src[i];
+
+      count.at(digit)--;
     }
     std::swap(src, dst);
   }
@@ -61,7 +64,7 @@ void VotincevDRadixMergeSortOMP::LocalRadixSort(uint32_t *begin, uint32_t *end) 
 }
 
 // слияние двух отсортированных участков
-void VotincevDRadixMergeSortOMP::Merge(const uint32_t *src, uint32_t *dst, int32_t left, int32_t mid, int32_t right) {
+void VotincevDRadixMergeSortTBB::Merge(const uint32_t *src, uint32_t *dst, int32_t left, int32_t mid, int32_t right) {
   int32_t i = left;
   int32_t j = mid;
   int32_t k = left;
@@ -92,7 +95,10 @@ void VotincevDRadixMergeSortTBB::ParallelRadixMergeSort(uint32_t *data, int32_t 
                        [&] { ParallelRadixMergeSort(data, mid, right, temp); });
 
   // слияние результатов
-  Merge(data, left, mid, right, temp);
+  Merge(data, temp, left, mid, right);
+
+  // копируем в основной массив
+  std::copy(temp + left, temp + right, data + left);
 }
 
 bool VotincevDRadixMergeSortTBB::RunImpl() {

--- a/tasks/votincev_d_radixmerge_sort/tests/functional/main.cpp
+++ b/tasks/votincev_d_radixmerge_sort/tests/functional/main.cpp
@@ -14,6 +14,7 @@
 #include "votincev_d_radixmerge_sort/common/include/common.hpp"
 #include "votincev_d_radixmerge_sort/omp/include/ops_omp.hpp"
 #include "votincev_d_radixmerge_sort/seq/include/ops_seq.hpp"
+#include "votincev_d_radixmerge_sort/tbb/include/ops_tbb.hpp"
 
 namespace votincev_d_radixmerge_sort {
 
@@ -78,7 +79,8 @@ const std::array<TestType, 10> kTestParam = {"test1", "test2", "test3", "test4",
 
 const auto kTestTasksList = std::tuple_cat(
     ppc::util::AddFuncTask<VotincevDRadixMergeSortSEQ, InType>(kTestParam, PPC_SETTINGS_votincev_d_radixmerge_sort),
-    ppc::util::AddFuncTask<VotincevDRadixMergeSortOMP, InType>(kTestParam, PPC_SETTINGS_votincev_d_radixmerge_sort));
+    ppc::util::AddFuncTask<VotincevDRadixMergeSortOMP, InType>(kTestParam, PPC_SETTINGS_votincev_d_radixmerge_sort),
+    ppc::util::AddFuncTask<VotincevDRadixMergeSortTBB, InType>(kTestParam, PPC_SETTINGS_votincev_d_radixmerge_sort));
 
 const auto kGtestValues = ppc::util::ExpandToValues(kTestTasksList);
 

--- a/tasks/votincev_d_radixmerge_sort/tests/performance/main.cpp
+++ b/tasks/votincev_d_radixmerge_sort/tests/performance/main.cpp
@@ -48,7 +48,7 @@ class VotincevDRadixMergeSortRunPerfTestsThreads : public ppc::util::BaseRunPerf
 namespace {
 const auto kAllPerfTasks =
     ppc::util::MakeAllPerfTasks<InType, VotincevDRadixMergeSortSEQ, VotincevDRadixMergeSortOMP,
-                                VotincevDRadixMergeSortOMP>(PPC_SETTINGS_votincev_d_radixmerge_sort);
+                                VotincevDRadixMergeSortTBB>(PPC_SETTINGS_votincev_d_radixmerge_sort);
 
 const auto kGtestValues = ppc::util::TupleToGTestValues(kAllPerfTasks);
 const auto kPerfTestName = VotincevDRadixMergeSortRunPerfTestsThreads::CustomPerfTestName;

--- a/tasks/votincev_d_radixmerge_sort/tests/performance/main.cpp
+++ b/tasks/votincev_d_radixmerge_sort/tests/performance/main.cpp
@@ -8,6 +8,7 @@
 #include "votincev_d_radixmerge_sort/common/include/common.hpp"
 #include "votincev_d_radixmerge_sort/omp/include/ops_omp.hpp"
 #include "votincev_d_radixmerge_sort/seq/include/ops_seq.hpp"
+#include "votincev_d_radixmerge_sort/tbb/include/ops_tbb.hpp"
 
 namespace votincev_d_radixmerge_sort {
 
@@ -45,8 +46,9 @@ class VotincevDRadixMergeSortRunPerfTestsThreads : public ppc::util::BaseRunPerf
 };
 
 namespace {
-const auto kAllPerfTasks = ppc::util::MakeAllPerfTasks<InType, VotincevDRadixMergeSortSEQ, VotincevDRadixMergeSortOMP>(
-    PPC_SETTINGS_votincev_d_radixmerge_sort);
+const auto kAllPerfTasks =
+    ppc::util::MakeAllPerfTasks<InType, VotincevDRadixMergeSortSEQ, VotincevDRadixMergeSortOMP,
+                                VotincevDRadixMergeSortOMP>(PPC_SETTINGS_votincev_d_radixmerge_sort);
 
 const auto kGtestValues = ppc::util::TupleToGTestValues(kAllPerfTasks);
 const auto kPerfTestName = VotincevDRadixMergeSortRunPerfTestsThreads::CustomPerfTestName;


### PR DESCRIPTION

## Описание
- **Задача**: Поразрядная сортировка для целых чисел с простым слиянием.
- **Вариант**: 17
- **Технология**: TBB
- **Описание** :
Алгоритм реализует гибридную сортировку на основе библиотеки Intel TBB (Threading Building Blocks): рекурсивное параллельное разделение данных (как в сортировке слиянием) с переключением на локальную поразрядную сортировку при достижении порога размера блока. Поразрядная сортировка использует 10 корзин (цифры от 0 до 9) и работает с десятичными разрядами (основание 10). Для корректной обработки отрицательных чисел выполняется нормализация – сдвиг всего диапазона значений в неотрицательную область.

### Основные этапы (TBB):

1. **Параллельное вычисление минимума**: Используется `tbb::parallel_reduce` для нахождения минимального значения в массиве. Каждый поток обрабатывает свой непрерывный блок (разбиение через `tbb::blocked_range`), затем результаты объединяются редукцией по операции `std::min`.

2. **Параллельная нормализация**: Посредством `tbb::parallel_for` каждый элемент преобразуется (вычитается минимум), становясь неотрицательным числом типа `uint32_t`. Это необходимо для корректной работы поразрядной сортировки.

3. **Рекурсивная параллельная сортировка** (`ParallelRadixMergeSort`):
   - Если размер блока (`right - left`) не превышает `grain_size = 4096`, выполняется последовательная `LocalRadixSort`.
   - Иначе блок делится пополам, и две половинки сортируются параллельно с помощью `tbb::parallel_invoke`.
   - После завершения сортировки половинок выполняется слияние (`Merge`) из временного буфера обратно в основной массив.

4. **Локальная поразрядная сортировка** (`LocalRadixSort`): LSD Radix Sort (Least Significant Digit) по основанию 10. Цифры извлекаются из чисел, и элементы распределяются по 10 корзинам последовательно, от младшего разряда к старшему.

5. **Параллельное восстановление диапазона**: С помощью `tbb::parallel_for` каждый элемент переводится обратно в исходный диапазон (прибавляется ранее вычтенный минимум). Результат помещается в выходной вектор.

### Особенности реализации:
- **Тип данных**: `int32_t` → нормализация → `uint32_t` → сортировка → обратное преобразование.
- **Основание поразрядной сортировки**: 10 (десятичные цифры).
- **Схема параллелизма**: рекурсивное разделение задач (divide-and-conquer) через `tbb::parallel_invoke`.
- **Порог переключения (`grain_size`)**: 4096 элементов – при меньшем размере блока используется последовательная поразрядная сортировка.
- **Рабочие буферы**: временный буфер `temp_buffer` того же размера, что и исходный массив, используется для слияний.
- **Планировщик TBB**: автоматически распределяет задачи по доступным потокам, балансируя нагрузку.

---

## Чек-лист
<!--
Пожалуйста, убедитесь, что следующие пункты выполнены **до** отправки pull request'а и запроса его ревью:
-->

- [x] **Статус CI**: Все CI-задачи (сборка, тесты, генерация отчёта) успешно проходят на моей ветке в моем форке
- [x] **Директория и именование задачи**: Я создал директорию с именем `<фамилия>_<первая_буква_имени>_<короткое_название_задачи>`
- [x] **Полное описание задачи**: Я предоставил полное описание задачи в теле pull request
- [x] **clang-format**: Мои изменения успешно проходят `clang-format` локально в моем форке (нет ошибок форматирования)
- [x] **clang-tidy**: Мои изменения успешно проходят `clang-tidy` локально в моем форке (нет предупреждений/ошибок)
- [x] **Функциональные тесты**: Все функциональные тесты успешно проходят локально на моей машине
- [x] **Тесты производительности**: Все тесты производительности успешно проходят локально на моей машине
- [x] **Ветка**: Я работаю в ветке, названной точно так же, как директория моей задачи
  (например, `nesterov_a_vector_sum`), а не в `master`
- [x] **Правдивое содержание**: Я подтверждаю, что все сведения, указанные в этом pull request, являются точными и
  достоверными

<!--
ПРИМЕЧАНИЕ: Ложные сведения в этом чек-листе могут привести к отклонению PR и получению нулевого балла
за соответствующую задачу.
-->
