### PR TITLE
Исправление: Лузан Егор. Технология SEQ. Умножение разреженных матриц. Элементы типа double. Формат хранения матрицы – столбцовый (CCS). Вариант 5.

### DIFF
--- a/tasks/luzan_e_double_sparse_matrix_mult/common/include/common.hpp
+++ b/tasks/luzan_e_double_sparse_matrix_mult/common/include/common.hpp
@@ -34,7 +34,8 @@ struct SparseMatrix {
     value.clear();
   }
 
-  SparseMatrix(const std::vector<double> &matrix, unsigned rows_out, unsigned cols_out) : cols(cols_out), rows(rows_out) {
+  SparseMatrix(const std::vector<double> &matrix, unsigned rows_out, unsigned cols_out)
+      : cols(cols_out), rows(rows_out) {
     col_index.clear();
     row.clear();
     value.clear();

--- a/tasks/luzan_e_double_sparse_matrix_mult/common/include/common.hpp
+++ b/tasks/luzan_e_double_sparse_matrix_mult/common/include/common.hpp
@@ -19,8 +19,8 @@ struct SparseMatrix {
   std::vector<unsigned> row;
   std::vector<unsigned> col_index;
 
-  unsigned cols;
   unsigned rows;
+  unsigned cols;
 
   SparseMatrix(unsigned rows_out, unsigned cols_out) : cols(cols_out), rows(rows_out) {
     col_index.clear();

--- a/tasks/luzan_e_double_sparse_matrix_mult/common/include/common.hpp
+++ b/tasks/luzan_e_double_sparse_matrix_mult/common/include/common.hpp
@@ -15,95 +15,95 @@ namespace luzan_e_double_sparse_matrix_mult {
 const double kEPS = 1e-8;
 
 struct SparseMatrix {
-  std::vector<double> value_;
-  std::vector<unsigned> row_;
-  std::vector<unsigned> col_index_;
+  std::vector<double> value;
+  std::vector<unsigned> row;
+  std::vector<unsigned> col_index;
 
   unsigned cols_;
   unsigned rows_;
 
   SparseMatrix(unsigned rows, unsigned cols) : cols_(cols), rows_(rows) {
-    col_index_.clear();
-    row_.clear();
-    value_.clear();
+    col_index.clear();
+    row.clear();
+    value.clear();
   }
 
   SparseMatrix() : cols_(0), rows_(0) {
-    col_index_.clear();
-    row_.clear();
-    value_.clear();
+    col_index.clear();
+    row.clear();
+    value.clear();
   }
 
   SparseMatrix(const std::vector<double> &matrix, unsigned rows, unsigned cols) : cols_(cols), rows_(rows) {
-    col_index_.clear();
-    row_.clear();
-    value_.clear();
+    col_index.clear();
+    row.clear();
+    value.clear();
 
     Sparse(matrix);
   }
 
   void GenLineMatrix(unsigned rows, unsigned cols) {
-    col_index_.clear();
-    row_.clear();
-    value_.clear();
+    col_index.clear();
+    row.clear();
+    value.clear();
 
     rows_ = rows;
     cols_ = cols;
 
-    col_index_.push_back(0);
+    col_index.push_back(0);
     for (unsigned j = 0; j < cols_; j++) {
       for (unsigned i = 0; i < rows_; i++) {
         if (i % 5 == 0) {
-          value_.push_back(1.0);
-          row_.push_back(i);
+          value.push_back(1.0);
+          row.push_back(i);
         }
       }
-      col_index_.push_back(value_.size());
+      col_index.push_back(value.size());
     }
   }
 
   void GenColsMatrix(unsigned rows, unsigned cols) {
-    col_index_.clear();
-    row_.clear();
-    value_.clear();
+    col_index.clear();
+    row.clear();
+    value.clear();
 
     rows_ = rows;
     cols_ = cols;
-    col_index_.push_back(0);
+    col_index.push_back(0);
 
     for (unsigned j = 0; j < cols_; j++) {
       if (j % 5 == 0) {
         for (unsigned i = 0; i < rows_; i++) {
-          value_.push_back(1.0);
-          row_.push_back(i);
+          value.push_back(1.0);
+          row.push_back(i);
         }
       }
 
-      col_index_.push_back(value_.size());
+      col_index.push_back(value.size());
     }
   }
 
   void GenPerfAns(unsigned n, unsigned m, unsigned k) {
-    col_index_.clear();
-    row_.clear();
-    value_.clear();
+    col_index.clear();
+    row.clear();
+    value.clear();
     rows_ = n;
     cols_ = m;
 
-    col_index_.push_back(0);
+    col_index.push_back(0);
     for (unsigned j = 0; j < m; j++) {
       if (j % 5 == 0)  // только чётные столбцы ненулевые
       {
         for (unsigned i = 0; i < n; i++) {
           if (i % 5 == 0)  // только чётные строки
           {
-            value_.push_back(static_cast<double>(k));
-            row_.push_back(i);
+            value.push_back(static_cast<double>(k));
+            row.push_back(i);
           }
         }
       }
 
-      col_index_.push_back(value_.size());
+      col_index.push_back(value.size());
     }
   }
 
@@ -116,48 +116,48 @@ struct SparseMatrix {
   }
 
   [[nodiscard]] std::vector<double> GetVal() const {
-    return value_;
+    return value;
   }
 
   bool operator==(const SparseMatrix &b) const {
     bool tmp = false;
-    if (value_.size() == b.value_.size()) {
+    if (value.size() == b.value.size()) {
       tmp = true;
-      for (size_t long_i = 0; long_i < value_.size(); long_i++) {
-        if (fabs(value_[long_i] - b.value_[long_i]) > kEPS) {
+      for (size_t long_i = 0; long_i < value.size(); long_i++) {
+        if (fabs(value[long_i] - b.value[long_i]) > kEPS) {
           tmp = false;
           break;
         }
       }
     }
 
-    return tmp && (row_ == b.row_) && (col_index_ == b.col_index_) && (cols_ == b.cols_) && (rows_ == b.rows_);
+    return tmp && (row == b.row) && (col_index == b.col_index) && (cols_ == b.cols_) && (rows_ == b.rows_);
   }
 
   double GetXy(unsigned x = 1, unsigned y = 2) {
-    for (unsigned verylongs = col_index_[y]; verylongs < col_index_[y + 1]; verylongs++) {
-      if (row_[verylongs] == x) {
-        return value_[verylongs];
+    for (unsigned verylongs = col_index[y]; verylongs < col_index[y + 1]; verylongs++) {
+      if (row[verylongs] == x) {
+        return value[verylongs];
       }
     }
     return 0.0;
   }
   void Sparse(const std::vector<double> &matrix) {
-    col_index_.push_back(0);
+    col_index.push_back(0);
     bool flag = false;
     for (unsigned j = 0; j < cols_; j++) {
-      col_index_.push_back(value_.size());
+      col_index.push_back(value.size());
 
       for (unsigned i = 0; i < rows_; i++) {
         if (fabs(matrix[(i * cols_) + j]) > kEPS) {
-          value_.push_back(matrix[(i * cols_) + j]);
-          row_.push_back(i);
+          value.push_back(matrix[(i * cols_) + j]);
+          row.push_back(i);
           flag = true;
         }
       }
       if (flag) {
-        col_index_.pop_back();
-        col_index_.push_back(value_.size());
+        col_index.pop_back();
+        col_index.push_back(value.size());
         flag = false;
       }
     }
@@ -165,33 +165,33 @@ struct SparseMatrix {
 
   SparseMatrix operator*(const SparseMatrix &b) const {
     SparseMatrix c(rows_, b.cols_);
-    c.col_index_.push_back(0);
+    c.col_index.push_back(0);
 
     for (unsigned b_col = 0; b_col < b.cols_; b_col++) {
       std::vector<double> tmp_col(rows_, 0);
-      unsigned b_rows_start = b.col_index_[b_col];
-      unsigned b_rows_end = b.col_index_[b_col + 1];
+      unsigned b_rows_start = b.col_index[b_col];
+      unsigned b_rows_end = b.col_index[b_col + 1];
 
       for (unsigned b_pos = b_rows_start; b_pos < b_rows_end; b_pos++) {
-        double b_val = b.value_[b_pos];
-        unsigned b_row = b.row_[b_pos];
+        double b_val = b.value[b_pos];
+        unsigned b_row = b.row[b_pos];
 
-        unsigned a_rows_start = col_index_[b_row];
-        unsigned a_rows_end = col_index_[b_row + 1];
+        unsigned a_rows_start = col_index[b_row];
+        unsigned a_rows_end = col_index[b_row + 1];
 
         for (unsigned a_pos = a_rows_start; a_pos < a_rows_end; a_pos++) {
-          double a_val = value_[a_pos];
-          unsigned a_row = row_[a_pos];
+          double a_val = value[a_pos];
+          unsigned a_row = row[a_pos];
           tmp_col[a_row] += a_val * b_val;
         }
       }
       for (unsigned i = 0; i < rows_; i++) {
         if (fabs(tmp_col[i]) > kEPS) {
-          c.value_.push_back(tmp_col[i]);
-          c.row_.push_back(i);
+          c.value.push_back(tmp_col[i]);
+          c.row.push_back(i);
         }
       }
-      c.col_index_.push_back(c.value_.size());
+      c.col_index.push_back(c.value.size());
     }
     return c;
   }
@@ -200,27 +200,27 @@ struct SparseMatrix {
     if (!file) {
       throw std::runtime_error("Cannot open file with sparsed matrix");
     }
-    value_.clear();
-    row_.clear();
-    col_index_.clear();
+    value.clear();
+    row.clear();
+    col_index.clear();
     unsigned n = 0;
     file >> n >> rows_ >> cols_;
 
     double tmp_val = 0;
     for (unsigned i = 0; i < n; i++) {
       file >> tmp_val;
-      value_.push_back(tmp_val);
+      value.push_back(tmp_val);
     }
 
     unsigned tmp = 0;
     for (unsigned i = 0; i < n; i++) {
       file >> tmp;
-      row_.push_back(tmp);
+      row.push_back(tmp);
     }
 
     for (unsigned i = 0; i < cols_ + 1; i++) {
       file >> tmp;
-      col_index_.push_back(tmp);
+      col_index.push_back(tmp);
     }
   }
 };

--- a/tasks/luzan_e_double_sparse_matrix_mult/common/include/common.hpp
+++ b/tasks/luzan_e_double_sparse_matrix_mult/common/include/common.hpp
@@ -19,22 +19,22 @@ struct SparseMatrix {
   std::vector<unsigned> row;
   std::vector<unsigned> col_index;
 
-  unsigned cols_;
-  unsigned rows_;
+  unsigned cols;
+  unsigned rows;
 
-  SparseMatrix(unsigned rows, unsigned cols) : cols_(cols), rows_(rows) {
+  SparseMatrix(unsigned rows_out, unsigned cols_out) : cols(cols_out), rows(rows_out) {
     col_index.clear();
     row.clear();
     value.clear();
   }
 
-  SparseMatrix() : cols_(0), rows_(0) {
+  SparseMatrix() : cols(0), rows(0) {
     col_index.clear();
     row.clear();
     value.clear();
   }
 
-  SparseMatrix(const std::vector<double> &matrix, unsigned rows, unsigned cols) : cols_(cols), rows_(rows) {
+  SparseMatrix(const std::vector<double> &matrix, unsigned rows_out, unsigned cols_out) : cols(cols_out), rows(rows_out) {
     col_index.clear();
     row.clear();
     value.clear();
@@ -42,17 +42,17 @@ struct SparseMatrix {
     Sparse(matrix);
   }
 
-  void GenLineMatrix(unsigned rows, unsigned cols) {
+  void GenLineMatrix(unsigned rows_out, unsigned cols_out) {
     col_index.clear();
     row.clear();
     value.clear();
 
-    rows_ = rows;
-    cols_ = cols;
+    rows = rows_out;
+    cols = cols_out;
 
     col_index.push_back(0);
-    for (unsigned j = 0; j < cols_; j++) {
-      for (unsigned i = 0; i < rows_; i++) {
+    for (unsigned j = 0; j < cols; j++) {
+      for (unsigned i = 0; i < rows; i++) {
         if (i % 5 == 0) {
           value.push_back(1.0);
           row.push_back(i);
@@ -62,18 +62,18 @@ struct SparseMatrix {
     }
   }
 
-  void GenColsMatrix(unsigned rows, unsigned cols) {
+  void GenColsMatrix(unsigned rows_out, unsigned cols_out) {
     col_index.clear();
     row.clear();
     value.clear();
 
-    rows_ = rows;
-    cols_ = cols;
+    rows = rows_out;
+    cols = cols_out;
     col_index.push_back(0);
 
-    for (unsigned j = 0; j < cols_; j++) {
+    for (unsigned j = 0; j < cols; j++) {
       if (j % 5 == 0) {
-        for (unsigned i = 0; i < rows_; i++) {
+        for (unsigned i = 0; i < rows; i++) {
           value.push_back(1.0);
           row.push_back(i);
         }
@@ -87,8 +87,8 @@ struct SparseMatrix {
     col_index.clear();
     row.clear();
     value.clear();
-    rows_ = n;
-    cols_ = m;
+    rows = n;
+    cols = m;
 
     col_index.push_back(0);
     for (unsigned j = 0; j < m; j++) {
@@ -108,11 +108,11 @@ struct SparseMatrix {
   }
 
   [[nodiscard]] unsigned GetCols() const {
-    return cols_;
+    return cols;
   }
 
   [[nodiscard]] unsigned GetRows() const {
-    return rows_;
+    return rows;
   }
 
   [[nodiscard]] std::vector<double> GetVal() const {
@@ -131,7 +131,7 @@ struct SparseMatrix {
       }
     }
 
-    return tmp && (row == b.row) && (col_index == b.col_index) && (cols_ == b.cols_) && (rows_ == b.rows_);
+    return tmp && (row == b.row) && (col_index == b.col_index) && (cols == b.cols) && (rows == b.rows);
   }
 
   double GetXy(unsigned x = 1, unsigned y = 2) {
@@ -145,12 +145,12 @@ struct SparseMatrix {
   void Sparse(const std::vector<double> &matrix) {
     col_index.push_back(0);
     bool flag = false;
-    for (unsigned j = 0; j < cols_; j++) {
+    for (unsigned j = 0; j < cols; j++) {
       col_index.push_back(value.size());
 
-      for (unsigned i = 0; i < rows_; i++) {
-        if (fabs(matrix[(i * cols_) + j]) > kEPS) {
-          value.push_back(matrix[(i * cols_) + j]);
+      for (unsigned i = 0; i < rows; i++) {
+        if (fabs(matrix[(i * cols) + j]) > kEPS) {
+          value.push_back(matrix[(i * cols) + j]);
           row.push_back(i);
           flag = true;
         }
@@ -164,11 +164,11 @@ struct SparseMatrix {
   }
 
   SparseMatrix operator*(const SparseMatrix &b) const {
-    SparseMatrix c(rows_, b.cols_);
+    SparseMatrix c(rows, b.cols);
     c.col_index.push_back(0);
 
-    for (unsigned b_col = 0; b_col < b.cols_; b_col++) {
-      std::vector<double> tmp_col(rows_, 0);
+    for (unsigned b_col = 0; b_col < b.cols; b_col++) {
+      std::vector<double> tmp_col(rows, 0);
       unsigned b_rows_start = b.col_index[b_col];
       unsigned b_rows_end = b.col_index[b_col + 1];
 
@@ -185,7 +185,7 @@ struct SparseMatrix {
           tmp_col[a_row] += a_val * b_val;
         }
       }
-      for (unsigned i = 0; i < rows_; i++) {
+      for (unsigned i = 0; i < rows; i++) {
         if (fabs(tmp_col[i]) > kEPS) {
           c.value.push_back(tmp_col[i]);
           c.row.push_back(i);
@@ -204,7 +204,7 @@ struct SparseMatrix {
     row.clear();
     col_index.clear();
     unsigned n = 0;
-    file >> n >> rows_ >> cols_;
+    file >> n >> rows >> cols;
 
     double tmp_val = 0;
     for (unsigned i = 0; i < n; i++) {
@@ -218,7 +218,7 @@ struct SparseMatrix {
       row.push_back(tmp);
     }
 
-    for (unsigned i = 0; i < cols_ + 1; i++) {
+    for (unsigned i = 0; i < cols + 1; i++) {
       file >> tmp;
       col_index.push_back(tmp);
     }

--- a/tasks/luzan_e_double_sparse_matrix_mult/common/include/common.hpp
+++ b/tasks/luzan_e_double_sparse_matrix_mult/common/include/common.hpp
@@ -14,7 +14,7 @@ namespace luzan_e_double_sparse_matrix_mult {
 
 const double kEPS = 1e-8;
 
-class SparseMatrix {
+struct SparseMatrix {
   std::vector<double> value_;
   std::vector<unsigned> row_;
   std::vector<unsigned> col_index_;
@@ -22,7 +22,6 @@ class SparseMatrix {
   unsigned cols_;
   unsigned rows_;
 
- public:
   SparseMatrix(unsigned rows, unsigned cols) : cols_(cols), rows_(rows) {
     col_index_.clear();
     row_.clear();

--- a/tasks/luzan_e_double_sparse_matrix_mult/common/include/common.hpp
+++ b/tasks/luzan_e_double_sparse_matrix_mult/common/include/common.hpp
@@ -19,8 +19,8 @@ struct SparseMatrix {
   std::vector<unsigned> row;
   std::vector<unsigned> col_index;
 
-  unsigned rows;
   unsigned cols;
+  unsigned rows;
 
   SparseMatrix(unsigned rows_out, unsigned cols_out) : cols(cols_out), rows(rows_out) {
     col_index.clear();

--- a/tasks/luzan_e_double_sparse_matrix_mult/common/include/common.hpp
+++ b/tasks/luzan_e_double_sparse_matrix_mult/common/include/common.hpp
@@ -116,7 +116,7 @@ class SparseMatrix {
     return rows_;
   }
 
-  [[nodiscard]] std::vector<double> GetVal() {
+  [[nodiscard]] std::vector<double> GetVal() const {
     return value_;
   }
 
@@ -143,7 +143,7 @@ class SparseMatrix {
     }
     return 0.0;
   }
-  void Sparse(std::vector<double> matrix) {
+  void Sparse(const std::vector<double>& matrix) {
     col_index_.push_back(0);
     bool flag = false;
     for (unsigned j = 0; j < cols_; j++) {
@@ -201,6 +201,9 @@ class SparseMatrix {
     if (!file) {
       throw std::runtime_error("Cannot open file with sparsed matrix");
     }
+    value_.clear();
+    row_.clear();
+    col_index_.clear();
     unsigned n = 0;
     file >> n >> rows_ >> cols_;
 

--- a/tasks/luzan_e_double_sparse_matrix_mult/common/include/common.hpp
+++ b/tasks/luzan_e_double_sparse_matrix_mult/common/include/common.hpp
@@ -143,7 +143,7 @@ class SparseMatrix {
     }
     return 0.0;
   }
-  void Sparse(const std::vector<double>& matrix) {
+  void Sparse(const std::vector<double> &matrix) {
     col_index_.push_back(0);
     bool flag = false;
     for (unsigned j = 0; j < cols_; j++) {


### PR DESCRIPTION
## Описание
<!--
Пожалуйста, укажите:
 1) Данные об исходной задаче (что именно исправляется)
 2) Детали исправления (что было не так и что вы изменили)
-->

### Данные об исходной задаче

- **Задача**: Умножение разреженных матриц. Элементы типа double. Формат хранения матрицы – столбцовый (CCS).
- **Вариант**: 5
- **Технология**: SEQ
- **Директория студента**: luzan_e_double_sparse_matrix_mult
- **Ссылка на исходный PR / коммит / issue**: [Исходный PR](https://github.com/learning-process/ppc-2026-threads/pull/214)
- **Полное описание исходной задачи**: 
В данной работе реализовано последовательное умножение двух разреженных матриц с типом элементов double. Матрицы хранятся в формате CCS, данный формат позволяет эффективно хранить разреженные матрицы, поскольку сохраняет только ненулевые элементы.

В работе реализована структура SparsedMatrix для хранения CCS матриц, включая преобразование из стандартного вида в CCS, оператор умножения матриц в CCS формате.

Алгоритм умножения представляет собой поэтапное накопление каждого столбца результирующей матрицы и затем преобразование его в CCS формат.

### Детали исправления

- **Проблема**: Затруднена реализация внешних по отношению к классу SparsedMatrix функций
- **Причина**: Неверное архитектурное решение
- **Суть исправления**: Тип SparsedMatrix изменён на структуру
- **Проверка**: Перезапуск тестов

---

## Чек-лист
<!--
Пожалуйста, убедитесь, что следующие пункты выполнены **до** отправки pull request'а и запроса его ревью:
-->

- [x] **Статус CI**: Все CI-задачи (сборка, тесты, генерация отчёта) успешно проходят на моей ветке в моем форке
- [x] **Директория и именование задачи**: Я не переименовывал существующую директорию задачи и не добавлял лишние
  директории задач
- [x] **Полное описание задачи**: Я указал полное описание исходной задачи и детали исправления в теле pull request
- [x] **clang-format**: Мои изменения успешно проходят `clang-format` локально в моем форке (нет ошибок форматирования)
- [x] **clang-tidy**: Мои изменения успешно проходят `clang-tidy` локально в моем форке (нет предупреждений/ошибок)
- [x] **Функциональные тесты**: Все функциональные тесты успешно проходят локально на моей машине
- [x] **Тесты производительности**: Все тесты производительности успешно проходят локально на моей машине (если
  применимо)
- [x] **Ветка**: Я работаю в отдельной ветке для исправления (а не в `master`)
- [x] **Правдивое содержание**: Я подтверждаю, что все сведения, указанные в этом pull request, являются точными и
  достоверными

<!--
ПРИМЕЧАНИЕ: Ложные сведения в этом чек-листе могут привести к отклонению PR и получению нулевого балла
за соответствующую задачу.
-->
