### PR TITLE
Кулик Артур. Технология TBB. Умножение разреженных матриц. Элементы типа double. Формат хранения матрицы – столбцовый (CCS). Вариант 5

### DIFF
--- a/tasks/kulik_a_mat_mul_double_ccs/tbb/include/ops_tbb.hpp
+++ b/tasks/kulik_a_mat_mul_double_ccs/tbb/include/ops_tbb.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "kulik_a_mat_mul_double_ccs/common/include/common.hpp"
+#include "task/include/task.hpp"
+
+namespace kulik_a_mat_mul_double_ccs {
+
+class KulikAMatMulDoubleCcsTBB : public BaseTask {
+ public:
+  static constexpr ppc::task::TypeOfTask GetStaticTypeOfTask() {
+    return ppc::task::TypeOfTask::kTBB;
+  }
+  explicit KulikAMatMulDoubleCcsTBB(const InType &in);
+
+ private:
+  bool ValidationImpl() override;
+  bool PreProcessingImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+};
+
+}  // namespace kulik_a_mat_mul_double_ccs

--- a/tasks/kulik_a_mat_mul_double_ccs/tbb/src/ops_tbb.cpp
+++ b/tasks/kulik_a_mat_mul_double_ccs/tbb/src/ops_tbb.cpp
@@ -1,0 +1,134 @@
+#include "kulik_a_mat_mul_double_ccs/tbb/include/ops_tbb.hpp"
+
+#include <tbb/blocked_range.h>
+#include <tbb/enumerable_thread_specific.h>
+#include <tbb/tbb.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <tuple>
+#include <vector>
+
+#include "kulik_a_mat_mul_double_ccs/common/include/common.hpp"
+#include "tbb/parallel_for.h"
+
+namespace kulik_a_mat_mul_double_ccs {
+
+namespace {
+
+inline void ProcessColumn(size_t j, const CCS &a, const CCS &b, std::vector<double> &accum,
+                          std::vector<bool> &nz_elem_rows, std::vector<size_t> &nnz_rows,
+                          std::vector<std::vector<double>> &local_values,
+                          std::vector<std::vector<size_t>> &local_rows) {
+  for (size_t k = b.col_ind[j]; k < b.col_ind[j + 1]; ++k) {
+    size_t ind = b.row[k];
+    double b_val = b.value[k];
+    for (size_t zc = a.col_ind[ind]; zc < a.col_ind[ind + 1]; ++zc) {
+      size_t i = a.row[zc];
+      double a_val = a.value[zc];
+
+      accum[i] += a_val * b_val;
+      if (!nz_elem_rows[i]) {
+        nz_elem_rows[i] = true;
+        nnz_rows.push_back(i);
+      }
+    }
+  }
+
+  std::ranges::sort(nnz_rows);
+
+  for (size_t i : nnz_rows) {
+    if (accum[i] != 0.0) {
+      local_rows[j].push_back(i);
+      local_values[j].push_back(accum[i]);
+    }
+    accum[i] = 0.0;
+    nz_elem_rows[i] = false;
+  }
+  nnz_rows.clear();
+}
+
+inline void CopyColumn(size_t j, CCS &c, const std::vector<std::vector<double>> &local_values,
+                       const std::vector<std::vector<size_t>> &local_rows) {
+  size_t offset = c.col_ind[j];
+  size_t col_nz = local_values[j].size();
+  for (size_t k = 0; k < col_nz; ++k) {
+    c.value[offset + k] = local_values[j][k];
+    c.row[offset + k] = local_rows[j][k];
+  }
+}
+
+}  // namespace
+
+struct ThreadLocalData {
+  std::vector<double> accum;
+  std::vector<bool> nz_elem_rows;
+  std::vector<size_t> nnz_rows;
+};
+
+KulikAMatMulDoubleCcsTBB::KulikAMatMulDoubleCcsTBB(const InType &in) {
+  SetTypeOfTask(GetStaticTypeOfTask());
+  GetInput() = in;
+}
+
+bool KulikAMatMulDoubleCcsTBB::ValidationImpl() {
+  const auto &a = std::get<0>(GetInput());
+  const auto &b = std::get<1>(GetInput());
+  return (a.m == b.n);
+}
+
+bool KulikAMatMulDoubleCcsTBB::PreProcessingImpl() {
+  return true;
+}
+
+bool KulikAMatMulDoubleCcsTBB::RunImpl() {
+  const auto &a = std::get<0>(GetInput());
+  const auto &b = std::get<1>(GetInput());
+  OutType &c = GetOutput();
+
+  c.n = a.n;
+  c.m = b.m;
+  c.col_ind.assign(c.m + 1, 0);
+
+  std::vector<std::vector<double>> local_values(b.m);
+  std::vector<std::vector<size_t>> local_rows(b.m);
+
+  ThreadLocalData exemplar;
+  exemplar.accum.assign(a.n, 0.0);
+  exemplar.nz_elem_rows.assign(a.n, false);
+
+  tbb::enumerable_thread_specific<ThreadLocalData> tls(exemplar);
+
+  tbb::parallel_for(tbb::blocked_range<size_t>(0, b.m), [&](const tbb::blocked_range<size_t> &r) {
+    auto &t_data = tls.local();
+
+    for (size_t j = r.begin(); j != r.end(); ++j) {
+      ProcessColumn(j, a, b, t_data.accum, t_data.nz_elem_rows, t_data.nnz_rows, local_values, local_rows);
+    }
+  });
+
+  size_t total_nz = 0;
+  for (size_t j = 0; j < b.m; ++j) {
+    c.col_ind[j] = total_nz;
+    total_nz += local_values[j].size();
+  }
+  c.col_ind[b.m] = total_nz;
+  c.nz = total_nz;
+
+  c.value.resize(total_nz);
+  c.row.resize(total_nz);
+
+  tbb::parallel_for(tbb::blocked_range<size_t>(0, b.m), [&](const tbb::blocked_range<size_t> &r) {
+    for (size_t j = r.begin(); j != r.end(); ++j) {
+      CopyColumn(j, c, local_values, local_rows);
+    }
+  });
+
+  return true;
+}
+
+bool KulikAMatMulDoubleCcsTBB::PostProcessingImpl() {
+  return true;
+}
+
+}  // namespace kulik_a_mat_mul_double_ccs

--- a/tasks/kulik_a_mat_mul_double_ccs/tests/functional/main.cpp
+++ b/tasks/kulik_a_mat_mul_double_ccs/tests/functional/main.cpp
@@ -13,6 +13,7 @@
 #include "kulik_a_mat_mul_double_ccs/common/include/common.hpp"
 #include "kulik_a_mat_mul_double_ccs/omp/include/ops_omp.hpp"
 #include "kulik_a_mat_mul_double_ccs/seq/include/ops_seq.hpp"
+#include "kulik_a_mat_mul_double_ccs/tbb/include/ops_tbb.hpp"
 #include "util/include/func_test_util.hpp"
 #include "util/include/util.hpp"
 
@@ -101,7 +102,8 @@ const std::array<TestType, 1> kTestParam = {std::make_tuple(std::string("matrix_
 
 const auto kTestTasksList = std::tuple_cat(
     ppc::util::AddFuncTask<KulikAMatMulDoubleCcsSEQ, InType>(kTestParam, PPC_SETTINGS_kulik_a_mat_mul_double_ccs),
-    ppc::util::AddFuncTask<KulikAMatMulDoubleCcsOMP, InType>(kTestParam, PPC_SETTINGS_kulik_a_mat_mul_double_ccs));
+    ppc::util::AddFuncTask<KulikAMatMulDoubleCcsOMP, InType>(kTestParam, PPC_SETTINGS_kulik_a_mat_mul_double_ccs),
+    ppc::util::AddFuncTask<KulikAMatMulDoubleCcsTBB, InType>(kTestParam, PPC_SETTINGS_kulik_a_mat_mul_double_ccs));
 
 const auto kGtestValues = ppc::util::ExpandToValues(kTestTasksList);
 

--- a/tasks/kulik_a_mat_mul_double_ccs/tests/performance/main.cpp
+++ b/tasks/kulik_a_mat_mul_double_ccs/tests/performance/main.cpp
@@ -10,6 +10,7 @@
 #include "kulik_a_mat_mul_double_ccs/common/include/common.hpp"
 #include "kulik_a_mat_mul_double_ccs/omp/include/ops_omp.hpp"
 #include "kulik_a_mat_mul_double_ccs/seq/include/ops_seq.hpp"
+#include "kulik_a_mat_mul_double_ccs/tbb/include/ops_tbb.hpp"
 #include "util/include/perf_test_util.hpp"
 
 namespace kulik_a_mat_mul_double_ccs {
@@ -18,55 +19,45 @@ class KulikARunPerfTestThreads : public ppc::util::BaseRunPerfTests<InType, OutT
   InType input_data_;
 
   void SetUp() override {
-    size_t n = 20000;
-    size_t m = 20000;
-    size_t k = 20000;         // Размеры матриц (n x k) и (k x m)
-    size_t nnz_per_col = 50;  // кол-во ненулевых элементов в столбце
-    size_t band_width = 175;  // ленточная матрица для лучшей локальности данных
+    int dim = 20000;
+    int seed = 0;
+    CCS &a = std::get<0>(input_data_);
+    CCS &b = std::get<1>(input_data_);
 
-    auto generate_ccs = [&](size_t rows, size_t cols) {
-      CCS mat;
-      mat.n = rows;
-      mat.m = cols;
-      mat.col_ind.assign(cols + 1, 0);
-      mat.row.reserve(cols * nnz_per_col);
-      mat.value.reserve(cols * nnz_per_col);
+    std::mt19937 rng(seed);
+    std::uniform_real_distribution<double> val_gen(1.0, 2.0);
 
-      std::random_device rd;
-      std::mt19937 gen(rd());
-      std::uniform_real_distribution<double> dist_val(-10.0, 10.0);
-
-      for (size_t j = 0; j < cols; ++j) {
-        mat.col_ind[j] = mat.row.size();
-        size_t min_r = 0;
-        if (j >= band_width) {
-          min_r = j - band_width;
-        }
-        size_t max_r = std::min(rows - 1, j + band_width);
-
-        std::vector<size_t> current_rows;
-        current_rows.push_back(j % rows);
-
-        std::uniform_int_distribution<size_t> dist_row(min_r, max_r);
-        while (current_rows.size() < nnz_per_col) {
-          size_t r = dist_row(gen);
-          if (std::ranges::find(current_rows, r) == current_rows.end()) {
-            current_rows.push_back(r);
-          }
-        }
-        std::ranges::sort(current_rows);
-        for (size_t row : current_rows) {
-          mat.row.push_back(row);
-          mat.value.push_back(dist_val(gen));
-        }
+    a.m = dim;
+    a.n = dim;
+    a.col_ind.assign(a.n + 1, 0);
+    for (size_t j = 0; j < a.n; ++j) {
+      int left = std::max(static_cast<int>(j - 50), 0);
+      int right = static_cast<int>(std::min(a.n, j + 50));
+      a.col_ind[j + 1] = a.col_ind[j] + right - left;
+      for (int k = left; k < right; ++k) {
+        double r = val_gen(rng);
+        a.row.push_back(k);
+        a.value.push_back(r);
       }
-      mat.col_ind[cols] = mat.row.size();
-      mat.nz = mat.row.size();
-      return mat;
-    };
+    }
 
-    input_data_ = std::make_tuple(generate_ccs(n, k), generate_ccs(k, m));
+    b.m = dim;
+    b.n = dim;
+    b.col_ind.assign(b.n + 1, 0);
+    for (size_t j = 0; j < b.n; ++j) {
+      int left = std::max(static_cast<int>(j - 50), 0);
+      int right = static_cast<int>(std::min(b.n, j + 50));
+      b.col_ind[j + 1] = b.col_ind[j] + right - left;
+      for (int k = left; k < right; ++k) {
+        double r = val_gen(rng);
+        b.row.push_back(k);
+        b.value.push_back(r);
+      }
+    }
+
+    input_data_ = std::make_tuple(a, b);
   }
+
   bool CheckTestOutputData(OutType &output_data) final {
     const auto &a = std::get<0>(input_data_);
     const auto &b = std::get<1>(input_data_);
@@ -126,8 +117,9 @@ TEST_P(KulikARunPerfTestThreads, RunPerfModes) {
 
 namespace {
 
-const auto kAllPerfTasks = ppc::util::MakeAllPerfTasks<InType, KulikAMatMulDoubleCcsSEQ, KulikAMatMulDoubleCcsOMP>(
-    PPC_SETTINGS_kulik_a_mat_mul_double_ccs);
+const auto kAllPerfTasks =
+    ppc::util::MakeAllPerfTasks<InType, KulikAMatMulDoubleCcsSEQ, KulikAMatMulDoubleCcsOMP, KulikAMatMulDoubleCcsTBB>(
+        PPC_SETTINGS_kulik_a_mat_mul_double_ccs);
 
 const auto kGtestValues = ppc::util::TupleToGTestValues(kAllPerfTasks);
 

--- a/tasks/kulik_a_mat_mul_double_ccs/tests/performance/main.cpp
+++ b/tasks/kulik_a_mat_mul_double_ccs/tests/performance/main.cpp
@@ -32,7 +32,7 @@ class KulikARunPerfTestThreads : public ppc::util::BaseRunPerfTests<InType, OutT
     a.col_ind.assign(a.n + 1, 0);
     b.col_ind.assign(b.n + 1, 0);
     for (size_t j = 0; j < a.n; ++j) {
-      size_t left = (j > 50) ? (j - 50) : 0;      
+      size_t left = (j > 50) ? (j - 50) : 0;
       size_t right = std::min(a.n, j + 50);
       a.col_ind[j + 1] = a.col_ind[j] + right - left;
       for (size_t k = left; k < right; ++k) {

--- a/tasks/kulik_a_mat_mul_double_ccs/tests/performance/main.cpp
+++ b/tasks/kulik_a_mat_mul_double_ccs/tests/performance/main.cpp
@@ -19,41 +19,40 @@ class KulikARunPerfTestThreads : public ppc::util::BaseRunPerfTests<InType, OutT
   InType input_data_;
 
   void SetUp() override {
-    int dim = 20000;
-    int seed = 0;
+    size_t size = 20000;
     CCS &a = std::get<0>(input_data_);
     CCS &b = std::get<1>(input_data_);
-
-    std::mt19937 rng(seed);
-    std::uniform_real_distribution<double> val_gen(1.0, 2.0);
-
-    a.m = dim;
-    a.n = dim;
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    std::uniform_real_distribution<double> dist_val(-10.0, 10.0);
+    a.m = size;
+    a.n = size;
+    b.m = size;
+    b.n = size;
     a.col_ind.assign(a.n + 1, 0);
+    b.col_ind.assign(b.n + 1, 0);
     for (size_t j = 0; j < a.n; ++j) {
-      int left = std::max(static_cast<int>(j - 50), 0);
-      int right = static_cast<int>(std::min(a.n, j + 50));
+      size_t left = (j > 50) ? (j - 50) : 0;      
+      size_t right = std::min(a.n, j + 50);
       a.col_ind[j + 1] = a.col_ind[j] + right - left;
-      for (int k = left; k < right; ++k) {
-        double r = val_gen(rng);
+      for (size_t k = left; k < right; ++k) {
+        double r = dist_val(gen);
         a.row.push_back(k);
         a.value.push_back(r);
       }
     }
-
-    b.m = dim;
-    b.n = dim;
-    b.col_ind.assign(b.n + 1, 0);
+    a.nz = a.row.size();
     for (size_t j = 0; j < b.n; ++j) {
-      int left = std::max(static_cast<int>(j - 50), 0);
-      int right = static_cast<int>(std::min(b.n, j + 50));
+      size_t left = (j > 50) ? (j - 50) : 0;
+      size_t right = std::min(b.n, j + 50);
       b.col_ind[j + 1] = b.col_ind[j] + right - left;
-      for (int k = left; k < right; ++k) {
-        double r = val_gen(rng);
+      for (size_t k = left; k < right; ++k) {
+        double r = dist_val(gen);
         b.row.push_back(k);
         b.value.push_back(r);
       }
     }
+    b.nz = b.row.size();
 
     input_data_ = std::make_tuple(a, b);
   }


### PR DESCRIPTION
## Описание

- **Задача**: Умножение разреженных матриц. Элементы типа double. Формат хранения матрицы – столбцовый (CCS).
- **Вариант**: 5
- **Технология**: TBB
- **Описание** вашей реализации и отчёта.  
  Реализована параллельная версия алгоритма умножения двух разреженных матриц, хранящихся в формате CCS (Compressed Column Storage) с элементами типа double, с помощью библиотеки TBB. Результат операции так же представлен в формате CCS.

## Описание реализации параллельной версии (TBB)
- Столбцы правой матрицы B обрабатываются параллельно с помощью шаблона ```tbb::parallel_for```.  Диапазон индексов столбцов [0; b.m) разбивается на блоки (```tbb::blocked_range```), которые автоматически распределяются между потоками TBB, обеспечивая динамическую балансировку нагрузки
- Каждый поток использует собственный экземпляр локальных данных, предоставляемый через ```tbb::enumerable_thread_specific<ThreadLocalData>```. В этот экземпляр входят: вектор-аккумулятор ```accum``` для накопления скалярных произведений, булев массив ```nz_elem_rows``` для отметки изменённых строк и список ```nnz_rows``` для запоминания индексов этих строк
- Внутри параллельного цикла поток последовательно обрабатывает назначенные ему столбцы. Для каждого столбца вызывается функция ```ProcessColumn```, которая умножает соответствующий столбец матрицы B на матрицу A, накапливая результат в локальных структурах потока. Ненулевые элементы текущего столбца записываются в общие векторы ```local_values[j]``` и ```local_rows[j]```, индексированные по номеру столбца
- После завершения обработки всех столбцов вычисляется общее количество ненулевых элементов в результирующей матрице C, заполняется массив указателей на столбцы ```col_ind``` и выделяется память под массивы ```row```  и ```value```
- На заключительном этапе с помощью ```tbb::parallel_for``` выполняется параллельное копирование данных из временных векторов ```local_values[j]``` и ```local_rows[j]``` в массивы матрицы C, с учётом смещений, записанных в ```col_ind```

## Описание тестирования
- Для функциональных тестов была взята матрица размером 6x6, произведение посчитано на бумаге в плотном формате и сравнено с результатом работы алгоритма
- Для тестов на производительность, в силу больших размеров матриц, нельзя вычислить результат на бумаге или на компьютере в плотном формате. Для проверки корректности использовался способ домножения справа на произвольный вектор: (A * B) * x = C * x. Воспользовавшись ассоциативностью умножения, получим A * (B * x) = C * x, где B * x и C * x - векторы. Такое матрично-векторное произведение (SpMV) легко вычислить на компьютере. Если конечные векторы слева и справа совпадают (с учетом погрешности конечной машинной арифметики), то матрицы A * B и C равны

## Описание генерации матриц
- Используются квадратные матрицы размера 20000 со средним числом элементов в столбце, равным 50 (матрица разрежена на 50 / 20000 * 100% = 0.25%). Матрицы генерируются ленточными (похожими на ленточные) для лучшей локальности данных

- [x] **Статус CI**: Все CI-задачи (сборка, тесты, генерация отчёта) успешно проходят на моей ветке в моем форке
- [x] **Директория и именование задачи**: Я создал директорию с именем `<фамилия>_<первая_буква_имени>_<короткое_название_задачи>`
- [x] **Полное описание задачи**: Я предоставил полное описание задачи в теле pull request
- [x] **clang-format**: Мои изменения успешно проходят `clang-format` локально в моем форке (нет ошибок форматирования)
- [x] **clang-tidy**: Мои изменения успешно проходят `clang-tidy` локально в моем форке (нет предупреждений/ошибок)
- [x] **Функциональные тесты**: Все функциональные тесты успешно проходят локально на моей машине
- [x] **Тесты производительности**: Все тесты производительности успешно проходят локально на моей машине
- [x] **Ветка**: Я работаю в ветке, названной точно так же, как директория моей задачи
  (например, `nesterov_a_vector_sum`), а не в `master`
- [x] **Правдивое содержание**: Я подтверждаю, что все сведения, указанные в этом pull request, являются точными и
  достоверными