### PR TITLE
Пихотский Роман. Технология OMP. Линейная фильтрация изображений (вертикальное разбиение). Ядро Гаусса 3x3. Вариант 25

### DIFF
--- a/tasks/pikhotskiy_r_vertical_gauss_filter/omp/include/ops_omp.hpp
+++ b/tasks/pikhotskiy_r_vertical_gauss_filter/omp/include/ops_omp.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+#include "pikhotskiy_r_vertical_gauss_filter/common/include/common.hpp"
+#include "task/include/task.hpp"
+
+namespace pikhotskiy_r_vertical_gauss_filter {
+
+class PikhotskiyRVerticalGaussFilterOMP : public BaseTask {
+ public:
+  static constexpr ppc::task::TypeOfTask GetStaticTypeOfTask() {
+    return ppc::task::TypeOfTask::kOMP;
+  }
+  explicit PikhotskiyRVerticalGaussFilterOMP(const InType &in);
+
+ private:
+  bool ValidationImpl() override;
+  bool PreProcessingImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+  void RunVerticalPassForStripe(int x_begin, int x_end);
+  void RunHorizontalPassForStripe(int x_begin, int x_end);
+
+  int width_ = 0;
+  int height_ = 0;
+  int stripe_width_ = 1;
+  std::vector<std::uint8_t> source_;
+  std::vector<int> vertical_buffer_;
+  std::vector<std::uint8_t> result_buffer_;
+};
+
+}  // namespace pikhotskiy_r_vertical_gauss_filter

--- a/tasks/pikhotskiy_r_vertical_gauss_filter/omp/src/ops_omp.cpp
+++ b/tasks/pikhotskiy_r_vertical_gauss_filter/omp/src/ops_omp.cpp
@@ -77,14 +77,14 @@ bool PikhotskiyRVerticalGaussFilterOMP::RunImpl() {
   const int stripe_count = (width_ + stripe_width_ - 1) / stripe_width_;
   omp_set_num_threads(num_threads);
 
-#pragma omp parallel for schedule(static)
+#pragma omp parallel for default(none) schedule(static) shared(stripe_count)
   for (int stripe_index = 0; stripe_index < stripe_count; ++stripe_index) {
     const int x_begin = stripe_index * stripe_width_;
     const int x_end = std::min(width_, x_begin + stripe_width_);
     RunVerticalPassForStripe(x_begin, x_end);
   }
 
-#pragma omp parallel for schedule(static)
+#pragma omp parallel for default(none) schedule(static) shared(stripe_count)
   for (int stripe_index = 0; stripe_index < stripe_count; ++stripe_index) {
     const int x_begin = stripe_index * stripe_width_;
     const int x_end = std::min(width_, x_begin + stripe_width_);

--- a/tasks/pikhotskiy_r_vertical_gauss_filter/omp/src/ops_omp.cpp
+++ b/tasks/pikhotskiy_r_vertical_gauss_filter/omp/src/ops_omp.cpp
@@ -1,0 +1,133 @@
+#include "pikhotskiy_r_vertical_gauss_filter/omp/include/ops_omp.hpp"
+
+#include <omp.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+
+#include "pikhotskiy_r_vertical_gauss_filter/common/include/common.hpp"
+#include "util/include/util.hpp"
+
+namespace pikhotskiy_r_vertical_gauss_filter {
+
+namespace {
+constexpr int kKernelNorm = 16;
+
+constexpr int ClampIndex(int value, int upper_bound) noexcept {
+  if (upper_bound <= 0) {
+    return 0;
+  }
+  if (value < 0) {
+    return 0;
+  }
+  if (value >= upper_bound) {
+    return upper_bound - 1;
+  }
+  return value;
+}
+
+constexpr std::size_t ToLinearIndex(int x_pos, int y_pos, int width) noexcept {
+  return (static_cast<std::size_t>(y_pos) * static_cast<std::size_t>(width)) + static_cast<std::size_t>(x_pos);
+}
+
+std::uint8_t NormalizeAndRoundUp(int sum) {
+  return static_cast<std::uint8_t>((sum + (kKernelNorm - 1)) / kKernelNorm);
+}
+}  // namespace
+
+PikhotskiyRVerticalGaussFilterOMP::PikhotskiyRVerticalGaussFilterOMP(const InType &in) {
+  SetTypeOfTask(GetStaticTypeOfTask());
+  GetInput() = in;
+  GetOutput() = OutType{};
+}
+
+bool PikhotskiyRVerticalGaussFilterOMP::ValidationImpl() {
+  const auto &in = GetInput();
+
+  if (in.width <= 0 || in.height <= 0) {
+    return false;
+  }
+  const auto expected_size = static_cast<std::size_t>(in.width) * static_cast<std::size_t>(in.height);
+  return in.data.size() == expected_size;
+}
+
+bool PikhotskiyRVerticalGaussFilterOMP::PreProcessingImpl() {
+  const auto &in = GetInput();
+  width_ = in.width;
+  height_ = in.height;
+
+  const int num_threads = std::max(1, ppc::util::GetNumThreads());
+  stripe_width_ = std::max(1, width_ / num_threads);
+
+  source_ = in.data;
+  vertical_buffer_.assign(source_.size(), 0);
+  result_buffer_.assign(source_.size(), 0);
+  return true;
+}
+
+bool PikhotskiyRVerticalGaussFilterOMP::RunImpl() {
+  const auto expected_size = static_cast<std::size_t>(width_) * static_cast<std::size_t>(height_);
+  if (width_ <= 0 || height_ <= 0 || source_.size() != expected_size || vertical_buffer_.size() != expected_size ||
+      result_buffer_.size() != expected_size) {
+    return false;
+  }
+
+  const int num_threads = std::max(1, ppc::util::GetNumThreads());
+  const int stripe_count = (width_ + stripe_width_ - 1) / stripe_width_;
+  omp_set_num_threads(num_threads);
+
+#pragma omp parallel for schedule(static)
+  for (int stripe_index = 0; stripe_index < stripe_count; ++stripe_index) {
+    const int x_begin = stripe_index * stripe_width_;
+    const int x_end = std::min(width_, x_begin + stripe_width_);
+    RunVerticalPassForStripe(x_begin, x_end);
+  }
+
+#pragma omp parallel for schedule(static)
+  for (int stripe_index = 0; stripe_index < stripe_count; ++stripe_index) {
+    const int x_begin = stripe_index * stripe_width_;
+    const int x_end = std::min(width_, x_begin + stripe_width_);
+    RunHorizontalPassForStripe(x_begin, x_end);
+  }
+
+  return true;
+}
+
+bool PikhotskiyRVerticalGaussFilterOMP::PostProcessingImpl() {
+  GetOutput().width = width_;
+  GetOutput().height = height_;
+  GetOutput().data = result_buffer_;
+  return true;
+}
+
+void PikhotskiyRVerticalGaussFilterOMP::RunVerticalPassForStripe(int x_begin, int x_end) {
+  for (int row = 0; row < height_; ++row) {
+    const int row_top = ClampIndex(row - 1, height_);
+    const int row_bottom = ClampIndex(row + 1, height_);
+
+    for (int col = x_begin; col < x_end; ++col) {
+      const std::size_t center = ToLinearIndex(col, row, width_);
+      const std::size_t top = ToLinearIndex(col, row_top, width_);
+      const std::size_t bottom = ToLinearIndex(col, row_bottom, width_);
+      vertical_buffer_[center] =
+          static_cast<int>(source_[top]) + (2 * static_cast<int>(source_[center])) + static_cast<int>(source_[bottom]);
+    }
+  }
+}
+
+void PikhotskiyRVerticalGaussFilterOMP::RunHorizontalPassForStripe(int x_begin, int x_end) {
+  for (int row = 0; row < height_; ++row) {
+    for (int col = x_begin; col < x_end; ++col) {
+      const int col_left = ClampIndex(col - 1, width_);
+      const int col_right = ClampIndex(col + 1, width_);
+      const std::size_t center = ToLinearIndex(col, row, width_);
+      const std::size_t left = ToLinearIndex(col_left, row, width_);
+      const std::size_t right = ToLinearIndex(col_right, row, width_);
+      const int weighted_sum = vertical_buffer_[left] + (2 * vertical_buffer_[center]) + vertical_buffer_[right];
+      result_buffer_[center] = NormalizeAndRoundUp(weighted_sum);
+    }
+  }
+}
+
+}  // namespace pikhotskiy_r_vertical_gauss_filter

--- a/tasks/pikhotskiy_r_vertical_gauss_filter/tests/functional/main.cpp
+++ b/tasks/pikhotskiy_r_vertical_gauss_filter/tests/functional/main.cpp
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "pikhotskiy_r_vertical_gauss_filter/common/include/common.hpp"
+#include "pikhotskiy_r_vertical_gauss_filter/omp/include/ops_omp.hpp"
 #include "pikhotskiy_r_vertical_gauss_filter/seq/include/ops_seq.hpp"
 #include "util/include/func_test_util.hpp"
 #include "util/include/util.hpp"
@@ -81,6 +82,9 @@ std::vector<ParamType> CreateTestParams() {
     params.emplace_back([](const InType &in) -> std::shared_ptr<BaseTask> {
       return std::make_shared<PikhotskiyRVerticalGaussFilterSEQ>(in);
     }, "seq", test_case);
+    params.emplace_back([](const InType &in) -> std::shared_ptr<BaseTask> {
+      return std::make_shared<PikhotskiyRVerticalGaussFilterOMP>(in);
+    }, "omp", test_case);
   }
   return params;
 }
@@ -118,6 +122,33 @@ TEST(PikhotskiyRVerticalGaussFilterInvalidTest, DataSizeMismatch) {
   input.height = 3;
   input.data = {1, 2, 3};
   auto task = std::make_shared<PikhotskiyRVerticalGaussFilterSEQ>(input);
+  EXPECT_FALSE(task->Validation());
+}
+
+TEST(PikhotskiyRVerticalGaussFilterInvalidTestOMP, ZeroWidth) {
+  Matrix input;
+  input.width = 0;
+  input.height = 5;
+  input.data.resize(5);
+  auto task = std::make_shared<PikhotskiyRVerticalGaussFilterOMP>(input);
+  EXPECT_FALSE(task->Validation());
+}
+
+TEST(PikhotskiyRVerticalGaussFilterInvalidTestOMP, ZeroHeight) {
+  Matrix input;
+  input.width = 5;
+  input.height = 0;
+  input.data.resize(5);
+  auto task = std::make_shared<PikhotskiyRVerticalGaussFilterOMP>(input);
+  EXPECT_FALSE(task->Validation());
+}
+
+TEST(PikhotskiyRVerticalGaussFilterInvalidTestOMP, DataSizeMismatch) {
+  Matrix input;
+  input.width = 3;
+  input.height = 3;
+  input.data = {1, 2, 3};
+  auto task = std::make_shared<PikhotskiyRVerticalGaussFilterOMP>(input);
   EXPECT_FALSE(task->Validation());
 }
 

--- a/tasks/pikhotskiy_r_vertical_gauss_filter/tests/performance/main.cpp
+++ b/tasks/pikhotskiy_r_vertical_gauss_filter/tests/performance/main.cpp
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "pikhotskiy_r_vertical_gauss_filter/common/include/common.hpp"
+#include "pikhotskiy_r_vertical_gauss_filter/omp/include/ops_omp.hpp"
 #include "pikhotskiy_r_vertical_gauss_filter/seq/include/ops_seq.hpp"
 #include "util/include/perf_test_util.hpp"
 
@@ -46,7 +47,8 @@ TEST_P(PikhotskiyRVerticalGaussFilterPerfTests, RunPerfModes) {
 
 namespace {
 
-const auto kAllPerfTasks = ppc::util::MakeAllPerfTasks<InType, PikhotskiyRVerticalGaussFilterSEQ>(
+const auto kAllPerfTasks = ppc::util::MakeAllPerfTasks<InType, PikhotskiyRVerticalGaussFilterSEQ,
+                                                       PikhotskiyRVerticalGaussFilterOMP>(
     PPC_SETTINGS_pikhotskiy_r_vertical_gauss_filter);
 
 const auto kGtestValues = ppc::util::TupleToGTestValues(kAllPerfTasks);

--- a/tasks/pikhotskiy_r_vertical_gauss_filter/tests/performance/main.cpp
+++ b/tasks/pikhotskiy_r_vertical_gauss_filter/tests/performance/main.cpp
@@ -47,9 +47,9 @@ TEST_P(PikhotskiyRVerticalGaussFilterPerfTests, RunPerfModes) {
 
 namespace {
 
-const auto kAllPerfTasks = ppc::util::MakeAllPerfTasks<InType, PikhotskiyRVerticalGaussFilterSEQ,
-                                                       PikhotskiyRVerticalGaussFilterOMP>(
-    PPC_SETTINGS_pikhotskiy_r_vertical_gauss_filter);
+const auto kAllPerfTasks =
+    ppc::util::MakeAllPerfTasks<InType, PikhotskiyRVerticalGaussFilterSEQ, PikhotskiyRVerticalGaussFilterOMP>(
+        PPC_SETTINGS_pikhotskiy_r_vertical_gauss_filter);
 
 const auto kGtestValues = ppc::util::TupleToGTestValues(kAllPerfTasks);
 


### PR DESCRIPTION
"Пихотский Роман. Технология OMP. Линейная фильтрация изображений (вертикальное разбиение). Ядро Гаусса 3x3. Вариант 25"
-->

## Описание
<!--
Пожалуйста, предоставьте подробное описание вашей реализации, включая:
 - основные детали решения (описание выбранного алгоритма)
 - применение технологии параллелизма (если применимо)
-->

- **Задача**: Линейная фильтрация изображений (вертикальное разбиение). Ядро Гаусса 3x3
- **Вариант**: 25
- **Технология**: OMP
- **Описание** вашей реализации и отчёта.  
  Реализована параллельная версия линейной фильтрации изображения ядром Гаусса 3x3 с использованием OpenMP и вертикального разбиения по столбцам. Алгоритм выполнен в два прохода: вертикальный (формирование промежуточного буфера) и горизонтальный (получение итогового изображения) с нормализацией на 16. Для корректной обработки границ используется прижатие индексов к диапазону изображения (clamp), что исключает артефакты на краях. В OMP-версии вычисления распределяются между потоками по вертикальным полосам с `#pragma omp parallel for schedule(static)`, каждая полоса обрабатывается независимо.

---

## Чек-лист
<!--
Пожалуйста, убедитесь, что следующие пункты выполнены **до** отправки pull request'а и запроса его ревью:
-->

- [x] **Статус CI**: Все CI-задачи (сборка, тесты, генерация отчёта) успешно проходят на моей ветке в моем форке
- [x] **Директория и именование задачи**: Я создал директорию с именем `<фамилия>_<первая_буква_имени>_<короткое_название_задачи>`
- [x] **Полное описание задачи**: Я предоставил полное описание задачи в теле pull request
- [x] **clang-format**: Мои изменения успешно проходят `clang-format` локально в моем форке (нет ошибок форматирования)
- [x] **clang-tidy**: Мои изменения успешно проходят `clang-tidy` локально в моем форке (нет предупреждений/ошибок)
- [x] **Функциональные тесты**: Все функциональные тесты успешно проходят локально на моей машине
- [x] **Тесты производительности**: Все тесты производительности успешно проходят локально на моей машине
- [x] **Ветка**: Я работаю в ветке, названной точно так же, как директория моей задачи
  (например, `nesterov_a_vector_sum`), а не в `master`
- [x] **Правдивое содержание**: Я подтверждаю, что все сведения, указанные в этом pull request, являются точными и
  достоверными

<!--
ПРИМЕЧАНИЕ: Ложные сведения в этом чек-листе могут привести к отклонению PR и получению нулевого балла
за соответствующую задачу.
-->
