### PR TITLE
Трофимов Никита. Технология STL. Сортировка Хоара с четно-нечетным слиянием Бэтчера. Вариант 14.

### DIFF
--- a/tasks/trofimov_n_hoar_sort_batcher/stl/include/ops_stl.hpp
+++ b/tasks/trofimov_n_hoar_sort_batcher/stl/include/ops_stl.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "task/include/task.hpp"
+#include "trofimov_n_hoar_sort_batcher/common/include/common.hpp"
+
+namespace trofimov_n_hoar_sort_batcher {
+
+class TrofimovNHoarSortBatcherSTL : public BaseTask {
+ public:
+  static constexpr ppc::task::TypeOfTask GetStaticTypeOfTask() {
+    return ppc::task::TypeOfTask::kSTL;
+  }
+  explicit TrofimovNHoarSortBatcherSTL(const InType &in);
+
+ private:
+  bool ValidationImpl() override;
+  bool PreProcessingImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+};
+
+}  // namespace trofimov_n_hoar_sort_batcher

--- a/tasks/trofimov_n_hoar_sort_batcher/stl/src/ops_stl.cpp
+++ b/tasks/trofimov_n_hoar_sort_batcher/stl/src/ops_stl.cpp
@@ -10,41 +10,68 @@ namespace trofimov_n_hoar_sort_batcher {
 
 namespace {
 
-int HoarePartition(std::vector<int> &arr, int left, int right) {
-  const int pivot = arr[left + ((right - left) / 2)];
-  int i = left - 1;
-  int j = right + 1;
+unsigned int GetThreadsCount(std::size_t size) {
+  unsigned int threads_count = std::thread::hardware_concurrency();
+  if (threads_count == 0) {
+    threads_count = 2;
+  }
+  return std::min<unsigned int>(threads_count, static_cast<unsigned int>(size));
+}
 
-  while (true) {
-    while (arr[++i] < pivot) {
-    }
+std::vector<std::pair<std::size_t, std::size_t>> BuildRanges(std::size_t size, unsigned int threads_count) {
+  const std::size_t chunk_size = (size + threads_count - 1) / static_cast<std::size_t>(threads_count);
+  std::vector<std::pair<std::size_t, std::size_t>> ranges;
+  ranges.reserve(threads_count);
 
-    while (arr[--j] > pivot) {
-    }
+  for (std::size_t begin = 0; begin < size; begin += chunk_size) {
+    const std::size_t end = std::min(begin + chunk_size, size);
+    ranges.emplace_back(begin, end);
+  }
+  return ranges;
+}
 
-    if (i >= j) {
-      return j;
-    }
-
-    std::swap(arr[i], arr[j]);
+void SortRangesInParallel(std::vector<int> &arr, const std::vector<std::pair<std::size_t, std::size_t>> &ranges) {
+  std::vector<std::thread> workers;
+  workers.reserve(ranges.size());
+  for (const auto &[begin, end] : ranges) {
+    workers.emplace_back([&arr, begin, end]() { std::sort(arr.begin() + begin, arr.begin() + end); });
+  }
+  for (auto &worker : workers) {
+    worker.join();
   }
 }
 
-void QuickSortStlTask(std::vector<int> &arr, int left, int right, int depth_limit) {
-  if (left >= right) {
+void MergeSortedRanges(std::vector<int> &arr, std::vector<std::pair<std::size_t, std::size_t>> &ranges) {
+  while (ranges.size() > 1) {
+    std::vector<std::pair<std::size_t, std::size_t>> merged_ranges;
+    merged_ranges.reserve((ranges.size() + 1) / 2);
+
+    for (std::size_t i = 0; i < ranges.size(); i += 2) {
+      if (i + 1 >= ranges.size()) {
+        merged_ranges.push_back(ranges[i]);
+        continue;
+      }
+
+      const auto [left_begin, left_end] = ranges[i];
+      const auto [right_begin, right_end] = ranges[i + 1];
+      std::inplace_merge(arr.begin() + left_begin, arr.begin() + left_end, arr.begin() + right_end);
+      merged_ranges.emplace_back(left_begin, right_end);
+    }
+
+    ranges.swap(merged_ranges);
+  }
+}
+
+void ParallelSortByChunks(std::vector<int> &arr) {
+  const std::size_t size = arr.size();
+  if (size <= 1) {
     return;
   }
 
-  constexpr int kSequentialThreshold = 1024;
-  if ((right - left) < kSequentialThreshold || depth_limit <= 0) {
-    std::sort(arr.begin() + left, arr.begin() + right + 1);
-    return;
-  }
-
-  const int split = HoarePartition(arr, left, right);
-  std::thread left_thread([&arr, left, split, depth_limit]() { QuickSortStlTask(arr, left, split, depth_limit - 1); });
-  QuickSortStlTask(arr, split + 1, right, depth_limit - 1);
-  left_thread.join();
+  const unsigned int threads_count = GetThreadsCount(size);
+  auto ranges = BuildRanges(size, threads_count);
+  SortRangesInParallel(arr, ranges);
+  MergeSortedRanges(arr, ranges);
 }
 
 }  // namespace
@@ -65,11 +92,7 @@ bool TrofimovNHoarSortBatcherSTL::PreProcessingImpl() {
 
 bool TrofimovNHoarSortBatcherSTL::RunImpl() {
   auto &data = GetOutput();
-
-  if (data.size() > 1) {
-    QuickSortStlTask(data, 0, static_cast<int>(data.size()) - 1, 4);
-  }
-
+  ParallelSortByChunks(data);
   return true;
 }
 

--- a/tasks/trofimov_n_hoar_sort_batcher/stl/src/ops_stl.cpp
+++ b/tasks/trofimov_n_hoar_sort_batcher/stl/src/ops_stl.cpp
@@ -31,22 +31,35 @@ int HoarePartition(std::vector<int> &arr, int left, int right) {
 }
 
 void QuickSortStlTask(std::vector<int> &arr, int left, int right, int depth_limit) {
-  if (left >= right) {
-    return;
-  }
-
   constexpr int kSequentialThreshold = 1024;
 
-  if ((right - left) < kSequentialThreshold || depth_limit <= 0) {
-    std::sort(arr.begin() + left, arr.begin() + right + 1);
-    return;
+  struct Segment {
+    int left;
+    int right;
+    int depth;
+  };
+
+  std::vector<Segment> stack;
+  stack.push_back({left, right, depth_limit});
+
+  while (!stack.empty()) {
+    Segment seg = stack.back();
+    stack.pop_back();
+
+    if (seg.left >= seg.right) {
+      continue;
+    }
+
+    if ((seg.right - seg.left) < kSequentialThreshold || seg.depth <= 0) {
+      std::sort(arr.begin() + seg.left, arr.begin() + seg.right + 1);
+      continue;
+    }
+
+    const int split = HoarePartition(arr, seg.left, seg.right);
+
+    stack.push_back({split + 1, seg.right, seg.depth - 1});
+    stack.push_back({seg.left, split, seg.depth - 1});
   }
-
-  const int split = HoarePartition(arr, left, right);
-
-  std::thread left_thread([&arr, left, split, depth_limit]() { QuickSortStlTask(arr, left, split, depth_limit - 1); });
-  QuickSortStlTask(arr, split + 1, right, depth_limit - 1);
-  left_thread.join();
 }
 
 }  // namespace

--- a/tasks/trofimov_n_hoar_sort_batcher/stl/src/ops_stl.cpp
+++ b/tasks/trofimov_n_hoar_sort_batcher/stl/src/ops_stl.cpp
@@ -31,35 +31,20 @@ int HoarePartition(std::vector<int> &arr, int left, int right) {
 }
 
 void QuickSortStlTask(std::vector<int> &arr, int left, int right, int depth_limit) {
-  constexpr int kSequentialThreshold = 1024;
-
-  struct Segment {
-    int left;
-    int right;
-    int depth;
-  };
-
-  std::vector<Segment> stack;
-  stack.push_back({left, right, depth_limit});
-
-  while (!stack.empty()) {
-    Segment seg = stack.back();
-    stack.pop_back();
-
-    if (seg.left >= seg.right) {
-      continue;
-    }
-
-    if ((seg.right - seg.left) < kSequentialThreshold || seg.depth <= 0) {
-      std::sort(arr.begin() + seg.left, arr.begin() + seg.right + 1);
-      continue;
-    }
-
-    const int split = HoarePartition(arr, seg.left, seg.right);
-
-    stack.push_back({split + 1, seg.right, seg.depth - 1});
-    stack.push_back({seg.left, split, seg.depth - 1});
+  if (left >= right) {
+    return;
   }
+
+  constexpr int kSequentialThreshold = 1024;
+  if ((right - left) < kSequentialThreshold || depth_limit <= 0) {
+    std::sort(arr.begin() + left, arr.begin() + right + 1);
+    return;
+  }
+
+  const int split = HoarePartition(arr, left, right);
+  std::thread left_thread([&arr, left, split, depth_limit]() { QuickSortStlTask(arr, left, split, depth_limit - 1); });
+  QuickSortStlTask(arr, split + 1, right, depth_limit - 1);
+  left_thread.join();
 }
 
 }  // namespace

--- a/tasks/trofimov_n_hoar_sort_batcher/stl/src/ops_stl.cpp
+++ b/tasks/trofimov_n_hoar_sort_batcher/stl/src/ops_stl.cpp
@@ -1,7 +1,9 @@
 #include "trofimov_n_hoar_sort_batcher/stl/include/ops_stl.hpp"
 
 #include <algorithm>
+#include <cstddef>
 #include <thread>
+#include <utility>
 #include <vector>
 
 #include "trofimov_n_hoar_sort_batcher/common/include/common.hpp"
@@ -9,6 +11,10 @@
 namespace trofimov_n_hoar_sort_batcher {
 
 namespace {
+
+auto ItAt(std::vector<int> &arr, std::size_t index) {
+  return arr.begin() + static_cast<std::ptrdiff_t>(index);
+}
 
 unsigned int GetThreadsCount(std::size_t size) {
   unsigned int threads_count = std::thread::hardware_concurrency();
@@ -34,7 +40,7 @@ void SortRangesInParallel(std::vector<int> &arr, const std::vector<std::pair<std
   std::vector<std::thread> workers;
   workers.reserve(ranges.size());
   for (const auto &[begin, end] : ranges) {
-    workers.emplace_back([&arr, begin, end]() { std::sort(arr.begin() + begin, arr.begin() + end); });
+    workers.emplace_back([&arr, begin, end]() { std::sort(ItAt(arr, begin), ItAt(arr, end)); });
   }
   for (auto &worker : workers) {
     worker.join();
@@ -54,7 +60,7 @@ void MergeSortedRanges(std::vector<int> &arr, std::vector<std::pair<std::size_t,
 
       const auto [left_begin, left_end] = ranges[i];
       const auto [right_begin, right_end] = ranges[i + 1];
-      std::inplace_merge(arr.begin() + left_begin, arr.begin() + left_end, arr.begin() + right_end);
+      std::inplace_merge(ItAt(arr, left_begin), ItAt(arr, left_end), ItAt(arr, right_end));
       merged_ranges.emplace_back(left_begin, right_end);
     }
 

--- a/tasks/trofimov_n_hoar_sort_batcher/stl/src/ops_stl.cpp
+++ b/tasks/trofimov_n_hoar_sort_batcher/stl/src/ops_stl.cpp
@@ -1,0 +1,82 @@
+#include "trofimov_n_hoar_sort_batcher/stl/include/ops_stl.hpp"
+
+#include <algorithm>
+#include <thread>
+#include <vector>
+
+#include "trofimov_n_hoar_sort_batcher/common/include/common.hpp"
+
+namespace trofimov_n_hoar_sort_batcher {
+
+namespace {
+
+int HoarePartition(std::vector<int> &arr, int left, int right) {
+  const int pivot = arr[left + ((right - left) / 2)];
+  int i = left - 1;
+  int j = right + 1;
+
+  while (true) {
+    while (arr[++i] < pivot) {
+    }
+
+    while (arr[--j] > pivot) {
+    }
+
+    if (i >= j) {
+      return j;
+    }
+
+    std::swap(arr[i], arr[j]);
+  }
+}
+
+void QuickSortStlTask(std::vector<int> &arr, int left, int right, int depth_limit) {
+  if (left >= right) {
+    return;
+  }
+
+  constexpr int kSequentialThreshold = 1024;
+
+  if ((right - left) < kSequentialThreshold || depth_limit <= 0) {
+    std::sort(arr.begin() + left, arr.begin() + right + 1);
+    return;
+  }
+
+  const int split = HoarePartition(arr, left, right);
+
+  std::thread left_thread([&arr, left, split, depth_limit]() { QuickSortStlTask(arr, left, split, depth_limit - 1); });
+  QuickSortStlTask(arr, split + 1, right, depth_limit - 1);
+  left_thread.join();
+}
+
+}  // namespace
+
+TrofimovNHoarSortBatcherSTL::TrofimovNHoarSortBatcherSTL(const InType &in) {
+  SetTypeOfTask(GetStaticTypeOfTask());
+  GetInput() = in;
+}
+
+bool TrofimovNHoarSortBatcherSTL::ValidationImpl() {
+  return true;
+}
+
+bool TrofimovNHoarSortBatcherSTL::PreProcessingImpl() {
+  GetOutput() = GetInput();
+  return true;
+}
+
+bool TrofimovNHoarSortBatcherSTL::RunImpl() {
+  auto &data = GetOutput();
+
+  if (data.size() > 1) {
+    QuickSortStlTask(data, 0, static_cast<int>(data.size()) - 1, 4);
+  }
+
+  return true;
+}
+
+bool TrofimovNHoarSortBatcherSTL::PostProcessingImpl() {
+  return true;
+}
+
+}  // namespace trofimov_n_hoar_sort_batcher

--- a/tasks/trofimov_n_hoar_sort_batcher/tbb/include/ops_tbb.hpp
+++ b/tasks/trofimov_n_hoar_sort_batcher/tbb/include/ops_tbb.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "task/include/task.hpp"
+#include "trofimov_n_hoar_sort_batcher/common/include/common.hpp"
+
+namespace trofimov_n_hoar_sort_batcher {
+
+class TrofimovNHoarSortBatcherTBB : public BaseTask {
+ public:
+  static constexpr ppc::task::TypeOfTask GetStaticTypeOfTask() {
+    return ppc::task::TypeOfTask::kTBB;
+  }
+  explicit TrofimovNHoarSortBatcherTBB(const InType &in);
+
+ private:
+  bool ValidationImpl() override;
+  bool PreProcessingImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+};
+
+}  // namespace trofimov_n_hoar_sort_batcher

--- a/tasks/trofimov_n_hoar_sort_batcher/tbb/src/ops_tbb.cpp
+++ b/tasks/trofimov_n_hoar_sort_batcher/tbb/src/ops_tbb.cpp
@@ -1,0 +1,93 @@
+#include "trofimov_n_hoar_sort_batcher/tbb/include/ops_tbb.hpp"
+
+#include <algorithm>
+#include <vector>
+
+#include "oneapi/tbb/task_group.h"
+#include "trofimov_n_hoar_sort_batcher/common/include/common.hpp"
+
+namespace trofimov_n_hoar_sort_batcher {
+
+namespace {
+
+int HoarePartition(std::vector<int> &arr, int left, int right) {
+  const int pivot = arr[left + ((right - left) / 2)];
+  int i = left - 1;
+  int j = right + 1;
+
+  while (true) {
+    while (arr[++i] < pivot) {
+    }
+
+    while (arr[--j] > pivot) {
+    }
+
+    if (i >= j) {
+      return j;
+    }
+
+    std::swap(arr[i], arr[j]);
+  }
+}
+
+void QuickSortTbbTask(std::vector<int> &arr, int left, int right, int depth_limit) {
+  if (left >= right) {
+    return;
+  }
+
+  constexpr int kSequentialThreshold = 1024;
+
+  if ((right - left) < kSequentialThreshold || depth_limit <= 0) {
+    std::sort(arr.begin() + left, arr.begin() + right + 1);
+    return;
+  }
+
+  const int split = HoarePartition(arr, left, right);
+
+  oneapi::tbb::task_group tg;
+  if ((split - left) > kSequentialThreshold) {
+    tg.run([&arr, left, split, depth_limit]() { QuickSortTbbTask(arr, left, split, depth_limit - 1); });
+  } else {
+    std::sort(arr.begin() + left, arr.begin() + split + 1);
+  }
+
+  if ((right - (split + 1)) > kSequentialThreshold) {
+    tg.run([&arr, split, right, depth_limit]() { QuickSortTbbTask(arr, split + 1, right, depth_limit - 1); });
+  } else {
+    std::sort(arr.begin() + split + 1, arr.begin() + right + 1);
+  }
+
+  tg.wait();
+}
+
+}  // namespace
+
+TrofimovNHoarSortBatcherTBB::TrofimovNHoarSortBatcherTBB(const InType &in) {
+  SetTypeOfTask(GetStaticTypeOfTask());
+  GetInput() = in;
+}
+
+bool TrofimovNHoarSortBatcherTBB::ValidationImpl() {
+  return true;
+}
+
+bool TrofimovNHoarSortBatcherTBB::PreProcessingImpl() {
+  GetOutput() = GetInput();
+  return true;
+}
+
+bool TrofimovNHoarSortBatcherTBB::RunImpl() {
+  auto &data = GetOutput();
+
+  if (data.size() > 1) {
+    QuickSortTbbTask(data, 0, static_cast<int>(data.size()) - 1, 4);
+  }
+
+  return true;
+}
+
+bool TrofimovNHoarSortBatcherTBB::PostProcessingImpl() {
+  return true;
+}
+
+}  // namespace trofimov_n_hoar_sort_batcher

--- a/tasks/trofimov_n_hoar_sort_batcher/tests/functional/main.cpp
+++ b/tasks/trofimov_n_hoar_sort_batcher/tests/functional/main.cpp
@@ -10,6 +10,7 @@
 #include "trofimov_n_hoar_sort_batcher/common/include/common.hpp"
 #include "trofimov_n_hoar_sort_batcher/omp/include/ops_omp.hpp"
 #include "trofimov_n_hoar_sort_batcher/seq/include/ops_seq.hpp"
+#include "trofimov_n_hoar_sort_batcher/tbb/include/ops_tbb.hpp"
 #include "util/include/func_test_util.hpp"
 #include "util/include/util.hpp"
 
@@ -65,7 +66,8 @@ const std::array<TestType, 12> kTestParam = {
 
 const auto kTestTasksList = std::tuple_cat(
     ppc::util::AddFuncTask<TrofimovNHoarSortBatcherOMP, InType>(kTestParam, PPC_SETTINGS_trofimov_n_hoar_sort_batcher),
-    ppc::util::AddFuncTask<TrofimovNHoarSortBatcherSEQ, InType>(kTestParam, PPC_SETTINGS_trofimov_n_hoar_sort_batcher));
+    ppc::util::AddFuncTask<TrofimovNHoarSortBatcherSEQ, InType>(kTestParam, PPC_SETTINGS_trofimov_n_hoar_sort_batcher),
+    ppc::util::AddFuncTask<TrofimovNHoarSortBatcherTBB, InType>(kTestParam, PPC_SETTINGS_trofimov_n_hoar_sort_batcher));
 
 const auto kGtestValues = ppc::util::ExpandToValues(kTestTasksList);
 const auto kTestName = TrofimovNHoarSortBatcherFuncTests::PrintFuncTestName<TrofimovNHoarSortBatcherFuncTests>;

--- a/tasks/trofimov_n_hoar_sort_batcher/tests/functional/main.cpp
+++ b/tasks/trofimov_n_hoar_sort_batcher/tests/functional/main.cpp
@@ -10,6 +10,7 @@
 #include "trofimov_n_hoar_sort_batcher/common/include/common.hpp"
 #include "trofimov_n_hoar_sort_batcher/omp/include/ops_omp.hpp"
 #include "trofimov_n_hoar_sort_batcher/seq/include/ops_seq.hpp"
+#include "trofimov_n_hoar_sort_batcher/stl/include/ops_stl.hpp"
 #include "trofimov_n_hoar_sort_batcher/tbb/include/ops_tbb.hpp"
 #include "util/include/func_test_util.hpp"
 #include "util/include/util.hpp"
@@ -67,6 +68,7 @@ const std::array<TestType, 12> kTestParam = {
 const auto kTestTasksList = std::tuple_cat(
     ppc::util::AddFuncTask<TrofimovNHoarSortBatcherOMP, InType>(kTestParam, PPC_SETTINGS_trofimov_n_hoar_sort_batcher),
     ppc::util::AddFuncTask<TrofimovNHoarSortBatcherSEQ, InType>(kTestParam, PPC_SETTINGS_trofimov_n_hoar_sort_batcher),
+    ppc::util::AddFuncTask<TrofimovNHoarSortBatcherSTL, InType>(kTestParam, PPC_SETTINGS_trofimov_n_hoar_sort_batcher),
     ppc::util::AddFuncTask<TrofimovNHoarSortBatcherTBB, InType>(kTestParam, PPC_SETTINGS_trofimov_n_hoar_sort_batcher));
 
 const auto kGtestValues = ppc::util::ExpandToValues(kTestTasksList);

--- a/tasks/trofimov_n_hoar_sort_batcher/tests/performance/main.cpp
+++ b/tasks/trofimov_n_hoar_sort_batcher/tests/performance/main.cpp
@@ -8,6 +8,7 @@
 #include "trofimov_n_hoar_sort_batcher/common/include/common.hpp"
 #include "trofimov_n_hoar_sort_batcher/omp/include/ops_omp.hpp"
 #include "trofimov_n_hoar_sort_batcher/seq/include/ops_seq.hpp"
+#include "trofimov_n_hoar_sort_batcher/tbb/include/ops_tbb.hpp"
 #include "util/include/perf_test_util.hpp"
 
 namespace trofimov_n_hoar_sort_batcher {
@@ -44,8 +45,8 @@ TEST_P(TrofimovNHoarSortBatcherPerfTests, RunPerfTests) {
 
 namespace {
 const auto kAllPerfTasks =
-    ppc::util::MakeAllPerfTasks<InType, TrofimovNHoarSortBatcherOMP, TrofimovNHoarSortBatcherSEQ>(
-        PPC_SETTINGS_trofimov_n_hoar_sort_batcher);
+    ppc::util::MakeAllPerfTasks<InType, TrofimovNHoarSortBatcherOMP, TrofimovNHoarSortBatcherSEQ,
+                                TrofimovNHoarSortBatcherTBB>(PPC_SETTINGS_trofimov_n_hoar_sort_batcher);
 
 const auto kGtestValues = ppc::util::TupleToGTestValues(kAllPerfTasks);
 const auto kPerfTestName = TrofimovNHoarSortBatcherPerfTests::CustomPerfTestName;

--- a/tasks/trofimov_n_hoar_sort_batcher/tests/performance/main.cpp
+++ b/tasks/trofimov_n_hoar_sort_batcher/tests/performance/main.cpp
@@ -8,6 +8,7 @@
 #include "trofimov_n_hoar_sort_batcher/common/include/common.hpp"
 #include "trofimov_n_hoar_sort_batcher/omp/include/ops_omp.hpp"
 #include "trofimov_n_hoar_sort_batcher/seq/include/ops_seq.hpp"
+#include "trofimov_n_hoar_sort_batcher/stl/include/ops_stl.hpp"
 #include "trofimov_n_hoar_sort_batcher/tbb/include/ops_tbb.hpp"
 #include "util/include/perf_test_util.hpp"
 
@@ -44,9 +45,9 @@ TEST_P(TrofimovNHoarSortBatcherPerfTests, RunPerfTests) {
 }
 
 namespace {
-const auto kAllPerfTasks =
-    ppc::util::MakeAllPerfTasks<InType, TrofimovNHoarSortBatcherOMP, TrofimovNHoarSortBatcherSEQ,
-                                TrofimovNHoarSortBatcherTBB>(PPC_SETTINGS_trofimov_n_hoar_sort_batcher);
+const auto kAllPerfTasks = ppc::util::MakeAllPerfTasks<InType, TrofimovNHoarSortBatcherOMP, TrofimovNHoarSortBatcherSEQ,
+                                                       TrofimovNHoarSortBatcherSTL, TrofimovNHoarSortBatcherTBB>(
+    PPC_SETTINGS_trofimov_n_hoar_sort_batcher);
 
 const auto kGtestValues = ppc::util::TupleToGTestValues(kAllPerfTasks);
 const auto kPerfTestName = TrofimovNHoarSortBatcherPerfTests::CustomPerfTestName;


### PR DESCRIPTION
<!--
Требования к названию pull request:

"<Фамилия> <Имя>. Технология <TECHNOLOGY_NAME:SEQ|OMP|TBB|STL|MPI>. <Полное название задачи>. Вариант <Номер>"
-->

## Описание
<!--
Пожалуйста, предоставьте подробное описание вашей реализации, включая:
 - основные детали решения (описание выбранного алгоритма)
 - применение технологии параллелизма (если применимо)
-->

- **Задача**: Сортировка Хоара с четно-нечетным слиянием Бэтчера.
- **Вариант**: 14
- **Технология**: STL
- **Описание** 
 В реализации используется параллельная быстрая сортировка Хоара с потоками STL: массив делится на две части, после чего левая половина сортируется в отдельном потоке через std::thread, а правая — в текущем потоке, что обеспечивает параллельное выполнение. Порог перехода на последовательную сортировку через std::sort составляет 1024 элемента, глубина рекурсии ограничена 4 уровнями.

---

## Чек-лист
<!--
Пожалуйста, убедитесь, что следующие пункты выполнены **до** отправки pull request'а и запроса его ревью:
-->

- [x] **Статус CI**: Все CI-задачи (сборка, тесты, генерация отчёта) успешно проходят на моей ветке в моем форке
- [x] **Директория и именование задачи**: Я создал директорию с именем `<фамилия>_<первая_буква_имени>_<короткое_название_задачи>`
- [x] **Полное описание задачи**: Я предоставил полное описание задачи в теле pull request
- [x] **clang-format**: Мои изменения успешно проходят `clang-format` локально в моем форке (нет ошибок форматирования)
- [x] **clang-tidy**: Мои изменения успешно проходят `clang-tidy` локально в моем форке (нет предупреждений/ошибок)
- [x] **Функциональные тесты**: Все функциональные тесты успешно проходят локально на моей машине
- [x] **Тесты производительности**: Все тесты производительности успешно проходят локально на моей машине
- [x] **Ветка**: Я работаю в ветке, названной точно так же, как директория моей задачи
  (например, `nesterov_a_vector_sum`), а не в `master`
- [x] **Правдивое содержание**: Я подтверждаю, что все сведения, указанные в этом pull request, являются точными и
  достоверными

<!--
ПРИМЕЧАНИЕ: Ложные сведения в этом чек-листе могут привести к отклонению PR и получению нулевого балла
за соответствующую задачу.
-->
