### PR TITLE
Кондаков Владислав. Технология TBB. Сортировка Шелла с простым слиянием. Вариант 15

### DIFF
--- a/tasks/kondakov_v_shell_sort/tbb/include/ops_tbb.hpp
+++ b/tasks/kondakov_v_shell_sort/tbb/include/ops_tbb.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "kondakov_v_shell_sort/common/include/common.hpp"
+#include "task/include/task.hpp"
+
+namespace kondakov_v_shell_sort {
+
+class KondakovVShellSortTBB : public BaseTask {
+ public:
+  static constexpr ppc::task::TypeOfTask GetStaticTypeOfTask() {
+    return ppc::task::TypeOfTask::kTBB;
+  }
+  explicit KondakovVShellSortTBB(const InType &in);
+
+ private:
+  bool ValidationImpl() override;
+  bool PreProcessingImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+};
+
+}  // namespace kondakov_v_shell_sort

--- a/tasks/kondakov_v_shell_sort/tbb/src/ops_tbb.cpp
+++ b/tasks/kondakov_v_shell_sort/tbb/src/ops_tbb.cpp
@@ -1,0 +1,155 @@
+#include "kondakov_v_shell_sort/tbb/include/ops_tbb.hpp"
+
+#include <oneapi/tbb/blocked_range.h>
+#include <oneapi/tbb/parallel_for.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <utility>
+#include <vector>
+
+#include "kondakov_v_shell_sort/common/include/common.hpp"
+#include "util/include/util.hpp"
+
+namespace kondakov_v_shell_sort {
+
+namespace {
+
+struct RunBounds {
+  size_t begin;
+  size_t end;
+};
+
+void SortRunWithShellGaps(std::vector<int> &data) {
+  const size_t n = data.size();
+  for (size_t gap = n / 2; gap > 0; gap /= 2) {
+    for (size_t i = gap; i < n; ++i) {
+      int value = data[i];
+      size_t j = i;
+      while (j >= gap && data[j - gap] > value) {
+        data[j] = data[j - gap];
+        j -= gap;
+      }
+      data[j] = value;
+    }
+  }
+}
+
+std::vector<int> MergeTwoSortedRuns(const std::vector<int> &left, const std::vector<int> &right) {
+  std::vector<int> result(left.size() + right.size());
+  size_t i = 0;
+  size_t j = 0;
+  size_t k = 0;
+
+  while (i < left.size() && j < right.size()) {
+    if (left[i] <= right[j]) {
+      result[k++] = left[i++];
+    } else {
+      result[k++] = right[j++];
+    }
+  }
+
+  while (i < left.size()) {
+    result[k++] = left[i++];
+  }
+
+  while (j < right.size()) {
+    result[k++] = right[j++];
+  }
+
+  return result;
+}
+
+size_t GetRunsCount(size_t data_size, int requested_threads) {
+  if (data_size == 0) {
+    return 0;
+  }
+  const int threads = std::max(1, requested_threads);
+  return std::min(static_cast<size_t>(threads), data_size);
+}
+
+std::vector<RunBounds> BuildBalancedRuns(size_t data_size, size_t runs_count) {
+  std::vector<RunBounds> bounds(runs_count);
+  for (size_t run = 0; run < runs_count; ++run) {
+    bounds[run] = RunBounds{.begin = (run * data_size) / runs_count, .end = ((run + 1) * data_size) / runs_count};
+  }
+  return bounds;
+}
+
+std::vector<std::vector<int>> MakeSortedRuns(const std::vector<int> &data, const std::vector<RunBounds> &bounds) {
+  std::vector<std::vector<int>> runs(bounds.size());
+
+  oneapi::tbb::parallel_for(oneapi::tbb::blocked_range<size_t>(0, bounds.size()),
+                            [&](const oneapi::tbb::blocked_range<size_t> &range) {
+    for (size_t run = range.begin(); run != range.end(); ++run) {
+      const RunBounds &current = bounds[run];
+      runs[run] = std::vector<int>(data.begin() + static_cast<std::ptrdiff_t>(current.begin),
+                                   data.begin() + static_cast<std::ptrdiff_t>(current.end));
+      SortRunWithShellGaps(runs[run]);
+    }
+  });
+
+  return runs;
+}
+
+std::vector<int> MergeRunsByLevels(std::vector<std::vector<int>> runs) {
+  while (runs.size() > 1) {
+    const size_t pairs_count = runs.size() / 2;
+    std::vector<std::vector<int>> next_level(pairs_count + (runs.size() % 2));
+
+    oneapi::tbb::parallel_for(oneapi::tbb::blocked_range<size_t>(0, pairs_count),
+                              [&](const oneapi::tbb::blocked_range<size_t> &range) {
+      for (size_t pair = range.begin(); pair != range.end(); ++pair) {
+        next_level[pair] = MergeTwoSortedRuns(runs[2 * pair], runs[(2 * pair) + 1]);
+      }
+    });
+
+    if ((runs.size() % 2) != 0) {
+      next_level.back() = std::move(runs.back());
+    }
+    runs = std::move(next_level);
+  }
+
+  return std::move(runs.front());
+}
+
+}  // namespace
+
+KondakovVShellSortTBB::KondakovVShellSortTBB(const InType &in) {
+  SetTypeOfTask(GetStaticTypeOfTask());
+  GetInput() = in;
+  GetOutput() = in;
+}
+
+bool KondakovVShellSortTBB::ValidationImpl() {
+  return !GetInput().empty();
+}
+
+bool KondakovVShellSortTBB::PreProcessingImpl() {
+  GetOutput() = GetInput();
+  return true;
+}
+
+bool KondakovVShellSortTBB::RunImpl() {
+  std::vector<int> &data = GetOutput();
+  if (data.size() <= 1) {
+    return true;
+  }
+
+  const int num_threads = ppc::util::GetNumThreads();
+  const size_t runs_count = GetRunsCount(data.size(), num_threads);
+  if (runs_count <= 1) {
+    SortRunWithShellGaps(data);
+    return std::ranges::is_sorted(data);
+  }
+
+  const std::vector<RunBounds> bounds = BuildBalancedRuns(data.size(), runs_count);
+  data = MergeRunsByLevels(MakeSortedRuns(data, bounds));
+  return std::ranges::is_sorted(data);
+}
+
+bool KondakovVShellSortTBB::PostProcessingImpl() {
+  return !GetOutput().empty();
+}
+
+}  // namespace kondakov_v_shell_sort

--- a/tasks/kondakov_v_shell_sort/tests/functional/main.cpp
+++ b/tasks/kondakov_v_shell_sort/tests/functional/main.cpp
@@ -10,6 +10,7 @@
 #include "kondakov_v_shell_sort/common/include/common.hpp"
 #include "kondakov_v_shell_sort/omp/include/ops_omp.hpp"
 #include "kondakov_v_shell_sort/seq/include/ops_seq.hpp"
+#include "kondakov_v_shell_sort/tbb/include/ops_tbb.hpp"
 #include "util/include/func_test_util.hpp"
 #include "util/include/util.hpp"
 
@@ -80,7 +81,8 @@ const std::array<TestType, 12> kTestParam = []() {
 
 const auto kTestTasksList = std::tuple_cat(
     ppc::util::AddFuncTask<KondakovVShellSortOMP, InType>(kTestParam, PPC_SETTINGS_kondakov_v_shell_sort),
-    ppc::util::AddFuncTask<KondakovVShellSortSEQ, InType>(kTestParam, PPC_SETTINGS_kondakov_v_shell_sort));
+    ppc::util::AddFuncTask<KondakovVShellSortSEQ, InType>(kTestParam, PPC_SETTINGS_kondakov_v_shell_sort),
+    ppc::util::AddFuncTask<KondakovVShellSortTBB, InType>(kTestParam, PPC_SETTINGS_kondakov_v_shell_sort));
 
 const auto kGtestValues = ppc::util::ExpandToValues(kTestTasksList);
 

--- a/tasks/kondakov_v_shell_sort/tests/performance/main.cpp
+++ b/tasks/kondakov_v_shell_sort/tests/performance/main.cpp
@@ -7,6 +7,7 @@
 #include "kondakov_v_shell_sort/common/include/common.hpp"
 #include "kondakov_v_shell_sort/omp/include/ops_omp.hpp"
 #include "kondakov_v_shell_sort/seq/include/ops_seq.hpp"
+#include "kondakov_v_shell_sort/tbb/include/ops_tbb.hpp"
 #include "util/include/perf_test_util.hpp"
 
 namespace kondakov_v_shell_sort {
@@ -44,8 +45,9 @@ TEST_P(KondakovVRunPerfTestsShellSort, RunPerfModes) {
 
 namespace {
 
-const auto kAllPerfTasks = ppc::util::MakeAllPerfTasks<InType, KondakovVShellSortOMP, KondakovVShellSortSEQ>(
-    PPC_SETTINGS_kondakov_v_shell_sort);
+const auto kAllPerfTasks =
+    ppc::util::MakeAllPerfTasks<InType, KondakovVShellSortOMP, KondakovVShellSortSEQ, KondakovVShellSortTBB>(
+        PPC_SETTINGS_kondakov_v_shell_sort);
 
 const auto kGtestValues = ppc::util::TupleToGTestValues(kAllPerfTasks);
 


### PR DESCRIPTION
<!--
Требования к названию pull request:

"<Фамилия> <Имя>. Технология <TECHNOLOGY_NAME:SEQ|OMP|TBB|STL|MPI>. <Полное название задачи>. Вариант <Номер>"
-->

## Описание
<!--
Пожалуйста, предоставьте подробное описание вашей реализации, включая:
 - основные детали решения (описание выбранного алгоритма)
 - применение технологии параллелизма (если применимо)
-->

- **Задача**:  Сортировка Шелла с простым слиянием
- **Вариант**:  Вариант 15
- **Технология**: TBB
- **Описание** вашей реализации и отчёта.  
Реализация сортирует массив std::vector<int> следующим образом: исходный массив делится на p сегментов, где p -количество потоков, полученное через GetNumThreads()), далее каждый сегмент независимо сортируется алгоритмом Шелла с использованием tbb::parallel_for. После локальной сортировки сегменты объединяются попарно с помощью параллельного слияния (merge), формируя дерево слияний до получения одного отсортированного массива.

---

## Чек-лист
<!--
Пожалуйста, убедитесь, что следующие пункты выполнены **до** отправки pull request'а и запроса его ревью:
-->

- [X] **Статус CI**: Все CI-задачи (сборка, тесты, генерация отчёта) успешно проходят на моей ветке в моем форке
- [X] **Директория и именование задачи**: Я создал директорию с именем `<фамилия>_<первая_буква_имени>_<короткое_название_задачи>`
- [X] **Полное описание задачи**: Я предоставил полное описание задачи в теле pull request
- [X] **clang-format**: Мои изменения успешно проходят `clang-format` локально в моем форке (нет ошибок форматирования)
- [X] **clang-tidy**: Мои изменения успешно проходят `clang-tidy` локально в моем форке (нет предупреждений/ошибок)
- [X] **Функциональные тесты**: Все функциональные тесты успешно проходят локально на моей машине
- [X] **Тесты производительности**: Все тесты производительности успешно проходят локально на моей машине
- [X] **Ветка**: Я работаю в ветке, названной точно так же, как директория моей задачи
  (например, `nesterov_a_vector_sum`), а не в `master`
- [X] **Правдивое содержание**: Я подтверждаю, что все сведения, указанные в этом pull request, являются точными и
  достоверными

<!--
ПРИМЕЧАНИЕ: Ложные сведения в этом чек-листе могут привести к отклонению PR и получению нулевого балла
за соответствующую задачу.
-->
