### PR TITLE
Дилшодов Адхам. Технология OMP. Умножение разреженных матриц. Элементы типа double. Формат хранения матрицы – столбцовый (CCS). Вариант 5

### DIFF
--- a/tasks/dilshodov_a_spmm_double_css/omp/include/ops_omp.hpp
+++ b/tasks/dilshodov_a_spmm_double_css/omp/include/ops_omp.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "dilshodov_a_spmm_double_css/common/include/common.hpp"
+#include "task/include/task.hpp"
+
+namespace dilshodov_a_spmm_double_css {
+
+class DilshodovASpmmDoubleCssOmp : public BaseTask {
+ public:
+  static constexpr ppc::task::TypeOfTask GetStaticTypeOfTask() {
+    return ppc::task::TypeOfTask::kOMP;
+  }
+
+  explicit DilshodovASpmmDoubleCssOmp(const InType &in);
+
+ private:
+  bool ValidationImpl() override;
+  bool PreProcessingImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+};
+
+}  // namespace dilshodov_a_spmm_double_css

--- a/tasks/dilshodov_a_spmm_double_css/omp/src/ops_omp.cpp
+++ b/tasks/dilshodov_a_spmm_double_css/omp/src/ops_omp.cpp
@@ -1,0 +1,170 @@
+#include "dilshodov_a_spmm_double_css/omp/include/ops_omp.hpp"
+
+#include <omp.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <utility>
+#include <vector>
+
+#include "dilshodov_a_spmm_double_css/common/include/common.hpp"
+
+namespace dilshodov_a_spmm_double_css {
+
+namespace {
+constexpr double kEps = 1e-10;
+
+bool HasValidDimensions(const SparseMatrixCCS &m) {
+  return m.rows_count > 0 && m.cols_count > 0;
+}
+
+bool HasValidContainers(const SparseMatrixCCS &m) {
+  if (m.col_ptrs.size() != static_cast<size_t>(m.cols_count) + 1) {
+    return false;
+  }
+  if (m.row_indices.size() != m.values.size()) {
+    return false;
+  }
+  if (m.col_ptrs.empty() || m.col_ptrs.front() != 0) {
+    return false;
+  }
+  if (m.col_ptrs.back() < 0) {
+    return false;
+  }
+  if (static_cast<size_t>(m.col_ptrs.back()) != m.values.size()) {
+    return false;
+  }
+  return true;
+}
+
+bool HasValidColumnOrdering(const SparseMatrixCCS &m) {
+  for (int j = 0; j < m.cols_count; ++j) {
+    if (m.col_ptrs[j] > m.col_ptrs[j + 1]) {
+      return false;
+    }
+
+    int prev_row = -1;
+    for (int idx = m.col_ptrs[j]; idx < m.col_ptrs[j + 1]; ++idx) {
+      const int row = m.row_indices[idx];
+      if (row < 0 || row >= m.rows_count) {
+        return false;
+      }
+      if (row <= prev_row) {
+        return false;
+      }
+      prev_row = row;
+    }
+  }
+  return true;
+}
+
+bool IsValidCCS(const SparseMatrixCCS &m) {
+  return HasValidDimensions(m) && HasValidContainers(m) && HasValidColumnOrdering(m);
+}
+
+void AccumulateColumnProduct(const SparseMatrixCCS &lhs, const SparseMatrixCCS &rhs, int rhs_col,
+                             std::vector<double> &acc, std::vector<int> &marker, std::vector<int> &used_rows,
+                             std::vector<std::pair<int, double>> &col) {
+  used_rows.clear();
+  col.clear();
+
+  for (int idx_b = rhs.col_ptrs[rhs_col]; idx_b < rhs.col_ptrs[rhs_col + 1]; ++idx_b) {
+    const int k = rhs.row_indices[idx_b];
+    const double rhs_value = rhs.values[idx_b];
+
+    for (int idx_a = lhs.col_ptrs[k]; idx_a < lhs.col_ptrs[k + 1]; ++idx_a) {
+      const int row = lhs.row_indices[idx_a];
+      const double value = lhs.values[idx_a] * rhs_value;
+
+      if (marker[row] != rhs_col) {
+        marker[row] = rhs_col;
+        acc[row] = value;
+        used_rows.push_back(row);
+      } else {
+        acc[row] += value;
+      }
+    }
+  }
+
+  col.reserve(used_rows.size());
+  for (int row : used_rows) {
+    const double value = acc[row];
+    if (std::abs(value) > kEps) {
+      col.emplace_back(row, value);
+    }
+  }
+
+  std::ranges::sort(col, {}, &std::pair<int, double>::first);
+}
+
+void BuildOutputFromColumns(const std::vector<std::vector<std::pair<int, double>>> &column_results,
+                            SparseMatrixCCS &out) {
+  int offset = 0;
+  for (int col = 0; col < out.cols_count; ++col) {
+    for (const auto &[row, value] : column_results[col]) {
+      out.row_indices.push_back(row);
+      out.values.push_back(value);
+      ++offset;
+    }
+    out.col_ptrs[col + 1] = offset;
+  }
+}
+
+}  // namespace
+
+DilshodovASpmmDoubleCssOmp::DilshodovASpmmDoubleCssOmp(const InType &in) {
+  SetTypeOfTask(GetStaticTypeOfTask());
+  GetInput() = in;
+}
+
+bool DilshodovASpmmDoubleCssOmp::ValidationImpl() {
+  const auto &lhs = std::get<0>(GetInput());
+  const auto &rhs = std::get<1>(GetInput());
+  return IsValidCCS(lhs) && IsValidCCS(rhs) && lhs.cols_count == rhs.rows_count;
+}
+
+bool DilshodovASpmmDoubleCssOmp::PreProcessingImpl() {
+  GetOutput() = SparseMatrixCCS{};
+  return true;
+}
+
+bool DilshodovASpmmDoubleCssOmp::RunImpl() {
+  const auto &lhs = std::get<0>(GetInput());
+  const auto &rhs = std::get<1>(GetInput());
+  auto &out = GetOutput();
+
+  out.rows_count = lhs.rows_count;
+  out.cols_count = rhs.cols_count;
+  out.col_ptrs.assign(out.cols_count + 1, 0);
+  out.row_indices.clear();
+  out.values.clear();
+
+  std::vector<std::vector<std::pair<int, double>>> column_results(rhs.cols_count);
+
+#pragma omp parallel default(none) shared(lhs, rhs, column_results)
+  {
+    std::vector<double> acc(lhs.rows_count, 0.0);
+    std::vector<int> marker(lhs.rows_count, -1);
+    std::vector<int> used_rows;
+    used_rows.reserve(256);
+
+#pragma omp for schedule(dynamic)
+    for (int rhs_col = 0; rhs_col < rhs.cols_count; ++rhs_col) {
+      auto &col = column_results[rhs_col];
+      AccumulateColumnProduct(lhs, rhs, rhs_col, acc, marker, used_rows, col);
+    }
+  }
+
+  BuildOutputFromColumns(column_results, out);
+
+  out.non_zeros = static_cast<int>(out.values.size());
+  return true;
+}
+
+bool DilshodovASpmmDoubleCssOmp::PostProcessingImpl() {
+  GetOutput().non_zeros = static_cast<int>(GetOutput().values.size());
+  return true;
+}
+
+}  // namespace dilshodov_a_spmm_double_css

--- a/tasks/dilshodov_a_spmm_double_css/tests/functional/main.cpp
+++ b/tasks/dilshodov_a_spmm_double_css/tests/functional/main.cpp
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "dilshodov_a_spmm_double_css/common/include/common.hpp"
+#include "dilshodov_a_spmm_double_css/omp/include/ops_omp.hpp"
 #include "dilshodov_a_spmm_double_css/seq/include/ops_seq.hpp"
 #include "util/include/func_test_util.hpp"
 #include "util/include/util.hpp"
@@ -117,8 +118,9 @@ const std::array<TestType, 3> kTestParams = {
     std::make_tuple("RectangularCheck", DenseMatrix{{1.0, -1.0, 0.0}, {0.0, 2.0, 4.0}},
                     DenseMatrix{{3.0, 0.0}, {0.0, 5.0}, {6.0, 7.0}})};
 
-const auto kTestTasksList =
-    ppc::util::AddFuncTask<DilshodovASpmmDoubleCssSeq, InType>(kTestParams, PPC_SETTINGS_dilshodov_a_spmm_double_css);
+const auto kTestTasksList = std::tuple_cat(
+    ppc::util::AddFuncTask<DilshodovASpmmDoubleCssSeq, InType>(kTestParams, PPC_SETTINGS_dilshodov_a_spmm_double_css),
+    ppc::util::AddFuncTask<DilshodovASpmmDoubleCssOmp, InType>(kTestParams, PPC_SETTINGS_dilshodov_a_spmm_double_css));
 
 const auto kGtestValues = ppc::util::ExpandToValues(kTestTasksList);
 

--- a/tasks/dilshodov_a_spmm_double_css/tests/performance/main.cpp
+++ b/tasks/dilshodov_a_spmm_double_css/tests/performance/main.cpp
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "dilshodov_a_spmm_double_css/common/include/common.hpp"
+#include "dilshodov_a_spmm_double_css/omp/include/ops_omp.hpp"
 #include "dilshodov_a_spmm_double_css/seq/include/ops_seq.hpp"
 #include "performance/include/performance.hpp"
 #include "util/include/perf_test_util.hpp"
@@ -107,8 +108,8 @@ TEST_P(DilshodovASpmmDoubleCssExamplePerfTests, RunPerfModes) {
 
 namespace {
 
-const auto kAllPerfTasks =
-    ppc::util::MakeAllPerfTasks<InType, DilshodovASpmmDoubleCssSeq>(PPC_SETTINGS_dilshodov_a_spmm_double_css);
+const auto kAllPerfTasks = ppc::util::MakeAllPerfTasks<InType, DilshodovASpmmDoubleCssSeq, DilshodovASpmmDoubleCssOmp>(
+    PPC_SETTINGS_dilshodov_a_spmm_double_css);
 
 const auto kGtestValues = ppc::util::TupleToGTestValues(kAllPerfTasks);
 


### PR DESCRIPTION
<!--
Требования к названию pull request:

"<Фамилия> <Имя>. Технология <TECHNOLOGY_NAME:SEQ|OMP|TBB|STL|MPI>. <Полное название задачи>. Вариант <Номер>"
-->

## Описание
<!--
Пожалуйста, предоставьте подробное описание вашей реализации, включая:
 - основные детали решения (описание выбранного алгоритма)
 - применение технологии параллелизма (если применимо)
-->

- **Задача**: Умножение разреженных матриц. Элементы типа double. Формат хранения матрицы – столбцовый (CCS).
- **Вариант**:5
- **Технология**: OMP
- **Описание** вашей реализации и отчёта.  
Реализована OMP-версия умножения разреженных матриц double в формате CCS: входные матрицы проверяются на корректность структуры и согласованность размеров, затем столбцы результата вычисляются параллельно по столбцам правой матрицы с поток-локальным накоплением частичных сумм, после чего итоговая матрица формируется в формате CCS.

---

## Чек-лист
<!--
Пожалуйста, убедитесь, что следующие пункты выполнены **до** отправки pull request'а и запроса его ревью:
-->

- [x] **Статус CI**: Все CI-задачи (сборка, тесты, генерация отчёта) успешно проходят на моей ветке в моем форке
- [x] **Директория и именование задачи**: Я создал директорию с именем `<фамилия>_<первая_буква_имени>_<короткое_название_задачи>`
- [x] **Полное описание задачи**: Я предоставил полное описание задачи в теле pull request
- [x] **clang-format**: Мои изменения успешно проходят `clang-format` локально в моем форке (нет ошибок форматирования)
- [x] **clang-tidy**: Мои изменения успешно проходят `clang-tidy` локально в моем форке (нет предупреждений/ошибок)
- [x] **Функциональные тесты**: Все функциональные тесты успешно проходят локально на моей машине
- [x] **Тесты производительности**: Все тесты производительности успешно проходят локально на моей машине
- [x] **Ветка**: Я работаю в ветке, названной точно так же, как директория моей задачи
  (например, `nesterov_a_vector_sum`), а не в `master`
- [x] **Правдивое содержание**: Я подтверждаю, что все сведения, указанные в этом pull request, являются точными и
  достоверными

<!--
ПРИМЕЧАНИЕ: Ложные сведения в этом чек-листе могут привести к отклонению PR и получению нулевого балла
за соответствующую задачу.
-->