### PR TITLE
Гасенин Леонид. Технология ALL. Поиск кратчайших путей из одной вершины (алгоритм Дейкстры). Вариант 21.

### DIFF
--- a/tasks/gasenin_l_djstra/all/include/ops_all.hpp
+++ b/tasks/gasenin_l_djstra/all/include/ops_all.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+#include "gasenin_l_djstra/common/include/common.hpp"
+#include "task/include/task.hpp"
+
+namespace gasenin_l_djstra {
+
+class GaseninLDjstraALL : public BaseTask {
+ public:
+  static constexpr ppc::task::TypeOfTask GetStaticTypeOfTask() {
+    return ppc::task::TypeOfTask::kALL;
+  }
+  explicit GaseninLDjstraALL(const InType &in);
+
+ private:
+  bool ValidationImpl() override;
+  bool PreProcessingImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+
+  std::vector<InType> dist_;
+  std::vector<char> visited_;
+
+  int rank_{};
+  int size_{};
+  int local_n_{};
+  int start_v_{};
+  int64_t total_sum_{};
+};
+
+}  // namespace gasenin_l_djstra

--- a/tasks/gasenin_l_djstra/all/src/ops_all.cpp
+++ b/tasks/gasenin_l_djstra/all/src/ops_all.cpp
@@ -13,7 +13,6 @@
 #include "gasenin_l_djstra/common/include/common.hpp"
 
 namespace gasenin_l_djstra {
-
 namespace {
 
 void MinPairImpl(void *in, void *inout, const int *len, MPI_Datatype * /*dtype*/) {
@@ -25,6 +24,71 @@ void MinPairImpl(void *in, void *inout, const int *len, MPI_Datatype * /*dtype*/
       b[i + 1] = a[i + 1];
     }
   }
+}
+
+void MinPairMpi(void *in, void *inout, int *len, MPI_Datatype *dtype) {
+  const int *len_const = len;
+  MinPairImpl(in, inout, len_const, dtype);
+}
+
+void FindThreadLocalMinima(const std::vector<InType> &dist, const std::vector<char> &visited, int local_n, int start_v,
+                           InType inf, std::vector<InType> &thread_mins, std::vector<InType> &thread_vertices) {
+#pragma omp parallel default(none) shared(local_n, start_v, dist, visited, thread_mins, thread_vertices, inf)
+  {
+    const int tid = omp_get_thread_num();
+    InType t_min = inf;
+    InType t_v = -1;
+
+#pragma omp for nowait
+    for (int i = 0; i < local_n; ++i) {
+      if (visited[i] == 0 && dist[i] < t_min) {
+        t_min = dist[i];
+        t_v = start_v + i;
+      }
+    }
+
+    thread_mins[tid] = t_min;
+    thread_vertices[tid] = t_v;
+  }
+}
+
+std::pair<InType, InType> ReduceThreadMinima(const std::vector<InType> &thread_mins,
+                                             const std::vector<InType> &thread_vertices, int num_threads, InType inf) {
+  InType local_min = inf;
+  InType local_vertex = -1;
+  for (int i = 0; i < num_threads; ++i) {
+    if (thread_mins[i] < local_min) {
+      local_min = thread_mins[i];
+      local_vertex = thread_vertices[i];
+    }
+  }
+  return {local_min, local_vertex};
+}
+
+void UpdateLocalDistances(std::vector<InType> &dist, const std::vector<char> &visited, int local_n, int start_v,
+                          InType global_vertex, InType global_min) {
+#pragma omp parallel for default(none) shared(local_n, start_v, dist, visited, global_vertex, global_min)
+  for (int i = 0; i < local_n; ++i) {
+    if (visited[i] == 0) {
+      const InType global_i = start_v + i;
+      if (global_i != global_vertex) {
+        const InType weight = std::abs(global_vertex - global_i);
+        const InType new_dist = global_min + weight;
+        dist[i] = std::min(new_dist, dist[i]);
+      }
+    }
+  }
+}
+
+int64_t ComputeLocalSum(const std::vector<InType> &dist, int local_n, InType inf) {
+  int64_t local_sum = 0;
+#pragma omp parallel for reduction(+ : local_sum) default(none) shared(local_n, dist, inf)
+  for (int i = 0; i < local_n; ++i) {
+    if (dist[i] != inf) {
+      local_sum += dist[i];
+    }
+  }
+  return local_sum;
 }
 
 }  // namespace
@@ -77,12 +141,7 @@ bool GaseninLDjstraALL::RunImpl() {
   const int start_v = start_v_;
 
   MPI_Op min_pair_op = MPI_OP_NULL;
-  // Lambda wrapper to match MPI_User_function signature
-  auto min_pair_fn = [](void *in, void *inout, int *len, MPI_Datatype *dtype) {
-    const int *len_const = len;  // Explicit const to avoid warning
-    MinPairImpl(in, inout, len_const, dtype);
-  };
-  MPI_Op_create(min_pair_fn, 1, &min_pair_op);
+  MPI_Op_create(MinPairMpi, 1, &min_pair_op);
 
   int num_threads = 1;
 #pragma omp parallel default(none) shared(num_threads)
@@ -95,32 +154,9 @@ bool GaseninLDjstraALL::RunImpl() {
   std::vector<InType> thread_vertices(num_threads, -1);
 
   for (int iteration = 0; iteration < n; ++iteration) {
-#pragma omp parallel default(none) shared(local_n, start_v, dist, visited, thread_mins, thread_vertices, inf)
-    {
-      const int tid = omp_get_thread_num();
-      InType t_min = inf;
-      InType t_v = -1;
+    FindThreadLocalMinima(dist, visited, local_n, start_v, inf, thread_mins, thread_vertices);
 
-#pragma omp for nowait
-      for (int i = 0; i < local_n; ++i) {
-        if (visited[i] == 0 && dist[i] < t_min) {
-          t_min = dist[i];
-          t_v = start_v + i;
-        }
-      }
-
-      thread_mins[tid] = t_min;
-      thread_vertices[tid] = t_v;
-    }
-
-    InType local_min = inf;
-    InType local_vertex = -1;
-    for (int i = 0; i < num_threads; ++i) {
-      if (thread_mins[i] < local_min) {
-        local_min = thread_mins[i];
-        local_vertex = thread_vertices[i];
-      }
-    }
+    auto [local_min, local_vertex] = ReduceThreadMinima(thread_mins, thread_vertices, num_threads, inf);
 
     std::array<InType, 2> local_pair = {local_min, local_vertex};
     std::array<InType, 2> global_pair = {inf, -1};
@@ -137,30 +173,13 @@ bool GaseninLDjstraALL::RunImpl() {
       visited[global_vertex - start_v] = 1;
     }
 
-#pragma omp parallel for default(none) shared(local_n, start_v, dist, visited, global_vertex, global_min)
-    for (int i = 0; i < local_n; ++i) {
-      if (visited[i] == 0) {
-        const InType global_i = start_v + i;
-        if (global_i != global_vertex) {
-          const InType weight = std::abs(global_vertex - global_i);
-          const InType new_dist = global_min + weight;
-          dist[i] = std::min(new_dist, dist[i]);
-        }
-      }
-    }
+    UpdateLocalDistances(dist, visited, local_n, start_v, global_vertex, global_min);
   }
 
   MPI_Op_free(&min_pair_op);
 
-  int64_t local_sum = 0;
-#pragma omp parallel for reduction(+ : local_sum) default(none) shared(local_n, dist, inf)
-  for (int i = 0; i < local_n; ++i) {
-    if (dist[i] != inf) {
-      local_sum += dist[i];
-    }
-  }
-
-  MPI_Allreduce(&local_sum, &total_sum_, 1, MPI_LONG_LONG_INT, MPI_SUM, MPI_COMM_WORLD);
+  int64_t local_sum = ComputeLocalSum(dist, local_n, inf);
+  MPI_Allreduce(&local_sum, &total_sum_, 1, MPI_INT64_T, MPI_SUM, MPI_COMM_WORLD);
 
   return true;
 }

--- a/tasks/gasenin_l_djstra/all/src/ops_all.cpp
+++ b/tasks/gasenin_l_djstra/all/src/ops_all.cpp
@@ -137,12 +137,13 @@ bool GaseninLDjstraALL::RunImpl() {
   const int local_n = local_n_;
   const int start_v = start_v_;
 
-  auto min_pair_op_func = [](void *in, void *inout, int *len, MPI_Datatype *dtype) {
-    const int *len_const = len;
-    MinPairImpl(in, inout, len_const, dtype);
+  auto min_pair_op_func = [](void *in, void *inout, const int *len, MPI_Datatype *dtype) {
+    MinPairImpl(in, inout, len, dtype);
   };
+
   MPI_Op min_pair_op = MPI_OP_NULL;
-  MPI_Op_create(min_pair_op_func, 1, &min_pair_op);
+
+  MPI_Op_create(reinterpret_cast<MPI_User_function *>(+min_pair_op_func), 1, &min_pair_op);
 
   int num_threads = 1;
 #pragma omp parallel default(none) shared(num_threads)

--- a/tasks/gasenin_l_djstra/all/src/ops_all.cpp
+++ b/tasks/gasenin_l_djstra/all/src/ops_all.cpp
@@ -1,0 +1,165 @@
+#include "gasenin_l_djstra/all/include/ops_all.hpp"
+
+#include <mpi.h>
+#include <omp.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdlib>
+#include <limits>
+#include <vector>
+
+#include "gasenin_l_djstra/common/include/common.hpp"
+
+namespace gasenin_l_djstra {
+
+GaseninLDjstraALL::GaseninLDjstraALL(const InType &in) {
+  SetTypeOfTask(GetStaticTypeOfTask());
+  GetInput() = in;
+  GetOutput() = 0;
+}
+
+bool GaseninLDjstraALL::ValidationImpl() {
+  return GetInput() > 0;
+}
+
+bool GaseninLDjstraALL::PreProcessingImpl() {
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank_);
+  MPI_Comm_size(MPI_COMM_WORLD, &size_);
+
+  const InType n = GetInput();
+  const InType inf = std::numeric_limits<InType>::max();
+
+  const int chunk = n / size_;
+  const int rem = n % size_;
+
+  if (rank_ < rem) {
+    local_n_ = chunk + 1;
+    start_v_ = rank_ * local_n_;
+  } else {
+    local_n_ = chunk;
+    start_v_ = rem * (chunk + 1) + (rank_ - rem) * chunk;
+  }
+
+  dist_.assign(local_n_, inf);
+  visited_.assign(local_n_, 0);
+
+  if (0 >= start_v_ && 0 < start_v_ + local_n_) {
+    dist_[0 - start_v_] = 0;
+  }
+
+  return true;
+}
+
+void MinPair(void *in, void *inout, int *len, MPI_Datatype * /*dtype*/) {
+  InType *a = static_cast<InType *>(in);
+  InType *b = static_cast<InType *>(inout);
+  for (int i = 0; i < *len; i += 2) {
+    if (a[i] < b[i]) {
+      b[i] = a[i];
+      b[i + 1] = a[i + 1];
+    }
+  }
+}
+
+bool GaseninLDjstraALL::RunImpl() {
+  const InType n = GetInput();
+  const InType inf = std::numeric_limits<InType>::max();
+
+  std::vector<InType> &dist = dist_;
+  std::vector<char> &visited = visited_;
+  const int local_n = local_n_;
+  const int start_v = start_v_;
+
+  MPI_Op min_pair_op;
+  MPI_Op_create(MinPair, 1, &min_pair_op);
+
+  int num_threads = 1;
+#pragma omp parallel
+  {
+#pragma omp single
+    num_threads = omp_get_num_threads();
+  }
+
+  std::vector<InType> thread_mins(num_threads, inf);
+  std::vector<InType> thread_vertices(num_threads, -1);
+
+  for (int iteration = 0; iteration < n; ++iteration) {
+#pragma omp parallel default(none) shared(local_n, start_v, dist, visited, thread_mins, thread_vertices, inf)
+    {
+      const int tid = omp_get_thread_num();
+      InType t_min = inf;
+      InType t_v = -1;
+
+#pragma omp for nowait
+      for (int i = 0; i < local_n; ++i) {
+        if (visited[i] == 0 && dist[i] < t_min) {
+          t_min = dist[i];
+          t_v = start_v + i;
+        }
+      }
+
+      thread_mins[tid] = t_min;
+      thread_vertices[tid] = t_v;
+    }
+
+    InType local_min = inf;
+    InType local_vertex = -1;
+    for (int i = 0; i < num_threads; ++i) {
+      if (thread_mins[i] < local_min) {
+        local_min = thread_mins[i];
+        local_vertex = thread_vertices[i];
+      }
+    }
+
+    InType local_pair[2] = {local_min, local_vertex};
+    InType global_pair[2] = {inf, -1};
+    MPI_Allreduce(local_pair, global_pair, 1, MPI_LONG_LONG_INT, min_pair_op, MPI_COMM_WORLD);
+
+    InType global_min = global_pair[0];
+    InType global_vertex = global_pair[1];
+
+    if (global_vertex == -1) {
+      break;
+    }
+
+    if (global_vertex >= start_v && global_vertex < start_v + local_n) {
+      visited[global_vertex - start_v] = 1;
+    }
+
+#pragma omp parallel for default(none) shared(local_n, start_v, dist, visited, global_vertex, global_min)
+    for (int i = 0; i < local_n; ++i) {
+      if (visited[i] == 0) {
+        const InType global_i = start_v + i;
+        if (global_i != global_vertex) {
+          const InType weight = std::abs(global_vertex - global_i);
+          const InType new_dist = global_min + weight;
+          if (new_dist < dist[i]) {
+            dist[i] = new_dist;
+          }
+        }
+      }
+    }
+  }
+
+  MPI_Op_free(&min_pair_op);
+
+  int64_t local_sum = 0;
+#pragma omp parallel for reduction(+ : local_sum) default(none) shared(local_n, dist, inf)
+  for (int i = 0; i < local_n; ++i) {
+    if (dist[i] != inf) {
+      local_sum += dist[i];
+    }
+  }
+
+  MPI_Allreduce(&local_sum, &total_sum_, 1, MPI_LONG_LONG, MPI_SUM, MPI_COMM_WORLD);
+
+  return true;
+}
+
+bool GaseninLDjstraALL::PostProcessingImpl() {
+  GetOutput() = static_cast<OutType>(total_sum_);
+  return true;
+}
+
+}  // namespace gasenin_l_djstra

--- a/tasks/gasenin_l_djstra/all/src/ops_all.cpp
+++ b/tasks/gasenin_l_djstra/all/src/ops_all.cpp
@@ -4,6 +4,7 @@
 #include <omp.h>
 
 #include <algorithm>
+#include <array>
 #include <cstdint>
 #include <cstdlib>
 #include <limits>
@@ -12,6 +13,21 @@
 #include "gasenin_l_djstra/common/include/common.hpp"
 
 namespace gasenin_l_djstra {
+
+namespace {
+
+void MinPairImpl(void *in, void *inout, const int *len, MPI_Datatype * /*dtype*/) {
+  auto *a = static_cast<InType *>(in);
+  auto *b = static_cast<InType *>(inout);
+  for (int i = 0; i < *len; i += 2) {
+    if (a[i] < b[i]) {
+      b[i] = a[i];
+      b[i + 1] = a[i + 1];
+    }
+  }
+}
+
+}  // namespace
 
 GaseninLDjstraALL::GaseninLDjstraALL(const InType &in) {
   SetTypeOfTask(GetStaticTypeOfTask());
@@ -38,7 +54,7 @@ bool GaseninLDjstraALL::PreProcessingImpl() {
     start_v_ = rank_ * local_n_;
   } else {
     local_n_ = chunk;
-    start_v_ = rem * (chunk + 1) + (rank_ - rem) * chunk;
+    start_v_ = (rem * (chunk + 1)) + ((rank_ - rem) * chunk);
   }
 
   dist_.assign(local_n_, inf);
@@ -51,17 +67,6 @@ bool GaseninLDjstraALL::PreProcessingImpl() {
   return true;
 }
 
-static void MinPair(void *in, void *inout, int *len, MPI_Datatype * /*dtype*/) {
-  InType *a = static_cast<InType *>(in);
-  InType *b = static_cast<InType *>(inout);
-  for (int i = 0; i < *len; i += 2) {
-    if (a[i] < b[i]) {
-      b[i] = a[i];
-      b[i + 1] = a[i + 1];
-    }
-  }
-}
-
 bool GaseninLDjstraALL::RunImpl() {
   const InType n = GetInput();
   const InType inf = std::numeric_limits<InType>::max();
@@ -71,11 +76,16 @@ bool GaseninLDjstraALL::RunImpl() {
   const int local_n = local_n_;
   const int start_v = start_v_;
 
-  MPI_Op min_pair_op;
-  MPI_Op_create(MinPair, 1, &min_pair_op);
+  MPI_Op min_pair_op = MPI_OP_NULL;
+  // Lambda wrapper to match MPI_User_function signature
+  auto min_pair_fn = [](void *in, void *inout, int *len, MPI_Datatype *dtype) {
+    const int *len_const = len;  // Explicit const to avoid warning
+    MinPairImpl(in, inout, len_const, dtype);
+  };
+  MPI_Op_create(min_pair_fn, 1, &min_pair_op);
 
   int num_threads = 1;
-#pragma omp parallel
+#pragma omp parallel default(none) shared(num_threads)
   {
 #pragma omp single
     num_threads = omp_get_num_threads();
@@ -112,9 +122,9 @@ bool GaseninLDjstraALL::RunImpl() {
       }
     }
 
-    InType local_pair[2] = {local_min, local_vertex};
-    InType global_pair[2] = {inf, -1};
-    MPI_Allreduce(local_pair, global_pair, 1, MPI_LONG_LONG_INT, min_pair_op, MPI_COMM_WORLD);
+    std::array<InType, 2> local_pair = {local_min, local_vertex};
+    std::array<InType, 2> global_pair = {inf, -1};
+    MPI_Allreduce(local_pair.data(), global_pair.data(), 1, MPI_LONG_LONG_INT, min_pair_op, MPI_COMM_WORLD);
 
     InType global_min = global_pair[0];
     InType global_vertex = global_pair[1];
@@ -134,9 +144,7 @@ bool GaseninLDjstraALL::RunImpl() {
         if (global_i != global_vertex) {
           const InType weight = std::abs(global_vertex - global_i);
           const InType new_dist = global_min + weight;
-          if (new_dist < dist[i]) {
-            dist[i] = new_dist;
-          }
+          dist[i] = std::min(new_dist, dist[i]);
         }
       }
     }
@@ -152,7 +160,7 @@ bool GaseninLDjstraALL::RunImpl() {
     }
   }
 
-  MPI_Allreduce(&local_sum, &total_sum_, 1, MPI_LONG_LONG, MPI_SUM, MPI_COMM_WORLD);
+  MPI_Allreduce(&local_sum, &total_sum_, 1, MPI_LONG_LONG_INT, MPI_SUM, MPI_COMM_WORLD);
 
   return true;
 }

--- a/tasks/gasenin_l_djstra/all/src/ops_all.cpp
+++ b/tasks/gasenin_l_djstra/all/src/ops_all.cpp
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <limits>
+#include <utility>
 #include <vector>
 
 #include "gasenin_l_djstra/common/include/common.hpp"
@@ -24,11 +25,6 @@ void MinPairImpl(void *in, void *inout, const int *len, MPI_Datatype * /*dtype*/
       b[i + 1] = a[i + 1];
     }
   }
-}
-
-void MinPairMpi(void *in, void *inout, int *len, MPI_Datatype *dtype) {
-  const int *len_const = len;
-  MinPairImpl(in, inout, len_const, dtype);
 }
 
 void FindThreadLocalMinima(const std::vector<InType> &dist, const std::vector<char> &visited, int local_n, int start_v,
@@ -80,6 +76,7 @@ void UpdateLocalDistances(std::vector<InType> &dist, const std::vector<char> &vi
   }
 }
 
+// Compute local sum of distances (excluding INF)
 int64_t ComputeLocalSum(const std::vector<InType> &dist, int local_n, InType inf) {
   int64_t local_sum = 0;
 #pragma omp parallel for reduction(+ : local_sum) default(none) shared(local_n, dist, inf)
@@ -140,8 +137,12 @@ bool GaseninLDjstraALL::RunImpl() {
   const int local_n = local_n_;
   const int start_v = start_v_;
 
+  auto min_pair_op_func = [](void *in, void *inout, int *len, MPI_Datatype *dtype) {
+    const int *len_const = len;
+    MinPairImpl(in, inout, len_const, dtype);
+  };
   MPI_Op min_pair_op = MPI_OP_NULL;
-  MPI_Op_create(MinPairMpi, 1, &min_pair_op);
+  MPI_Op_create(min_pair_op_func, 1, &min_pair_op);
 
   int num_threads = 1;
 #pragma omp parallel default(none) shared(num_threads)

--- a/tasks/gasenin_l_djstra/all/src/ops_all.cpp
+++ b/tasks/gasenin_l_djstra/all/src/ops_all.cpp
@@ -51,7 +51,7 @@ bool GaseninLDjstraALL::PreProcessingImpl() {
   return true;
 }
 
-void MinPair(void *in, void *inout, int *len, MPI_Datatype * /*dtype*/) {
+static void MinPair(void *in, void *inout, int *len, MPI_Datatype * /*dtype*/) {
   InType *a = static_cast<InType *>(in);
   InType *b = static_cast<InType *>(inout);
   for (int i = 0; i < *len; i += 2) {

--- a/tasks/gasenin_l_djstra/tests/functional/main.cpp
+++ b/tasks/gasenin_l_djstra/tests/functional/main.cpp
@@ -5,6 +5,7 @@
 #include <string>
 #include <tuple>
 
+#include "gasenin_l_djstra/all/include/ops_all.hpp"
 #include "gasenin_l_djstra/common/include/common.hpp"
 #include "gasenin_l_djstra/omp/include/ops_omp.hpp"
 #include "gasenin_l_djstra/seq/include/ops_seq.hpp"
@@ -53,7 +54,8 @@ const auto kSeqTasks = ppc::util::AddFuncTask<GaseninLDjstraSEQ, InType>(kTestPa
 const auto kOmpTasks = ppc::util::AddFuncTask<GaseninLDjstraOMP, InType>(kTestParam, PPC_SETTINGS_gasenin_l_djstra);
 const auto kStlTasks = ppc::util::AddFuncTask<GaseninLDjstraSTL, InType>(kTestParam, PPC_SETTINGS_gasenin_l_djstra);
 const auto kTbbTasks = ppc::util::AddFuncTask<GaseninLDjstraTBB, InType>(kTestParam, PPC_SETTINGS_gasenin_l_djstra);
-const auto kTestTasksList = std::tuple_cat(kSeqTasks, kOmpTasks, kStlTasks, kTbbTasks);
+const auto kAllTasks = ppc::util::AddFuncTask<GaseninLDjstraALL, InType>(kTestParam, PPC_SETTINGS_gasenin_l_djstra);
+const auto kTestTasksList = std::tuple_cat(kSeqTasks, kOmpTasks, kStlTasks, kTbbTasks, kAllTasks);
 
 const auto kGtestValues = ppc::util::ExpandToValues(kTestTasksList);
 const auto kPerfTestName = GaseninLRunFuncTestsThreads::PrintFuncTestName<GaseninLRunFuncTestsThreads>;

--- a/tasks/gasenin_l_djstra/tests/performance/main.cpp
+++ b/tasks/gasenin_l_djstra/tests/performance/main.cpp
@@ -2,6 +2,7 @@
 
 #include <tuple>
 
+#include "gasenin_l_djstra/all/include/ops_all.hpp"
 #include "gasenin_l_djstra/common/include/common.hpp"
 #include "gasenin_l_djstra/omp/include/ops_omp.hpp"
 #include "gasenin_l_djstra/seq/include/ops_seq.hpp"
@@ -39,8 +40,11 @@ const auto kSeqPerfTasks = ppc::util::MakeAllPerfTasks<InType, GaseninLDjstraSEQ
 const auto kOmpPerfTasks = ppc::util::MakeAllPerfTasks<InType, GaseninLDjstraOMP>(PPC_SETTINGS_gasenin_l_djstra);
 const auto kStlPerfTasks = ppc::util::MakeAllPerfTasks<InType, GaseninLDjstraSTL>(PPC_SETTINGS_gasenin_l_djstra);
 const auto kTbbPerfTasks = ppc::util::MakeAllPerfTasks<InType, GaseninLDjstraTBB>(PPC_SETTINGS_gasenin_l_djstra);
-const auto kAllPerfTasks = std::tuple_cat(kSeqPerfTasks, kOmpPerfTasks, kStlPerfTasks, kTbbPerfTasks);
-const auto kGtestValues = ppc::util::TupleToGTestValues(kAllPerfTasks);
+const auto kAllPerfTasks = ppc::util::MakeAllPerfTasks<InType, GaseninLDjstraALL>(PPC_SETTINGS_gasenin_l_djstra);
+
+const auto kTestPerfTasksLists =
+    std::tuple_cat(kSeqPerfTasks, kOmpPerfTasks, kStlPerfTasks, kTbbPerfTasks, kAllPerfTasks);
+const auto kGtestValues = ppc::util::TupleToGTestValues(kTestPerfTasksLists);
 const auto kPerfTestName = DjkstraPerfTests::CustomPerfTestName;
 
 INSTANTIATE_TEST_SUITE_P(DjkstraSeqPerf, DjkstraPerfTests, kGtestValues, kPerfTestName);


### PR DESCRIPTION
- **Задача**: Поиск кратчайших путей из одной вершины (алгоритм Дейкстры).
- **Вариант**: 21.
- **Технология**: ALL (MPI + OpenMP)
- **Описание**:  
  Реализован параллельный алгоритм Дейкстры для поиска кратчайших расстояний от стартовой вершины (вершина 0) до всех остальных вершин в полном неориентированном графе, где вес ребра между вершинами `i` и `j` определяется как `|i - j|`.  
  Входным параметром является количество вершин `n` (тип `InType`). Результатом работы является сумма кратчайших расстояний от вершины 0 до всех вершин (включая 0). Для данного графа ожидаемое значение суммы вычисляется аналитически:
  ```math
  \text{sum} = \frac{n(n-1)}{2}
  ```
  Это позволяет легко проверить корректность реализации.

  **Параллельная реализация (OMP + MPI)**:
  - Граф разбивается между MPI‑процессами: каждый процесс отвечает за непрерывный диапазон вершин `[start_v, start_v + local_n)`.  
  - Внутри каждого MPI‑процесса используется многопоточность OpenMP для ускорения локальных вычислений.
  - Основной цикл алгоритма (выбор вершины с минимальным расстоянием и релаксация рёбер) выполняется совместно всеми MPI‑процессами. Для согласования глобального минимума применяется операция `MPI_Allreduce` с пользовательской операцией `MinPairImpl`, которая одновременно находит минимальное расстояние и соответствующую ему глобальную вершину.
  - После выбора глобальной вершины каждый процесс обновляет расстояния только для своего локального диапазона вершин. При этом для вычисления веса ребра используется формула `|global_vertex - global_i|`, где `global_i` — глобальный номер вершины.

  **Детали реализации**:
  - **Разделение данных**:  
    В `PreProcessingImpl()` вычисляются `local_n` и `start_v` для каждого MPI‑процесса на основе `n` и `size`. Массивы `dist_` и `visited_` выделяются размером `local_n`. Начальное расстояние для вершины 0 устанавливается в 0, остальные — в `inf` (`std::numeric_limits<InType>::max()`).
  - **Поиск локального минимума (OpenMP)**:  
    Функция `FindThreadLocalMinima` распараллеливает цикл по локальным вершинам с помощью `#pragma omp for nowait`. Каждый поток находит минимальное непосещённое расстояние в своей порции и сохраняет результат в массивы `thread_mins` и `thread_vertices` (индексация по идентификатору потока).
  - **Редукция внутри процесса**:  
    `ReduceThreadMinima` последовательно выбирает наименьшее значение среди локальных минимумов потоков. Полученная пара `(local_min, local_vertex)` используется в MPI‑редукции.
  - **Глобальный минимум через MPI**:  
    Создаётся пользовательская операция `MPI_Op` с помощью `MPI_Op_create`, которая вызывает `MinPairImpl`. Эта функция сравнивает пары `(dist, vertex)` и выбирает ту, у которой расстояние меньше.  
    Вызов `MPI_Allreduce` с этой операцией находит глобальный минимум и соответствующую вершину среди всех процессов.
  - **Обновление посещённой вершины**:  
    Если глобальная вершина принадлежит текущему процессу, соответствующий элемент массива `visited` устанавливается в 1.
  - **Релаксация рёбер (OpenMP)**:  
       Функция `UpdateLocalDistances` с помощью `#pragma omp parallel for` параллельно обновляет расстояния до всех локальных непосещённых вершин. Новое расстояние вычисляется как `global_min + |global_vertex - global_i|`, после чего применяется `std::min`.
  - **Вычисление итоговой суммы**:  
    После завершения основного цикла каждый процесс вычисляет сумму локальных расстояний (исключая бесконечности) с использованием OpenMP-редукции (`#pragma omp parallel for reduction(+:local_sum)`). Затем с помощью `MPI_Allreduce` с операцией `MPI_SUM` получается общая сумма `total_sum_`, которая записывается в выходной параметр в `PostProcessingImpl()`.
  - **Освобождение ресурсов**:  
    Пользовательская MPI-операция уничтожается вызовом `MPI_Op_free`.

- **Тестирование**:
  - **Функциональные тесты**:  
    Класс `GaseninLRunFuncTestsThreads` наследует `ppc::util::BaseRunFuncTests` и проверяет корректность реализаций (SEQ, OMP, STL, TBB, ALL) на наборах данных `n = 3, 5, 7`. Ожидаемый результат вычисляется по формуле `n(n-1)/2`. Все версии должны выдавать идентичный правильный ответ.
  - **Перформанс-тесты**:  
    Класс `DjkstraPerfTests` (наследует `ppc::util::BaseRunPerfTests`) использует `n = 200` для измерения времени выполнения каждой реализации в различных режимах (определяется утилитами `MakeAllPerfTasks`). Это позволяет оценить ускорение, достигаемое за счёт распараллеливания на OpenMP и MPI.

- **Заключение:**
Гибридная реализация алгоритма Дейкстры (OMP + MPI) успешно решает поставленную задачу для полного графа с весовой функцией `|i - j|`. Сочетание MPI для межпроцессного взаимодействия и OpenMP для внутрипроцессного распараллеливания обеспечивает эффективное использование распределённых вычислительных ресурсов. Функциональные тесты подтверждают корректность работы, а перформанс-тесты создают основу для дальнейшего анализа производительности.

---

## Чек-лист
<!--
Пожалуйста, убедитесь, что следующие пункты выполнены **до** отправки pull request'а и запроса его ревью:
-->

- [x] **Статус CI**: Все CI-задачи (сборка, тесты, генерация отчёта) успешно проходят на моей ветке в моем форке
- [x] **Директория и именование задачи**: Я создал директорию с именем `<фамилия>_<первая_буква_имени>_<короткое_название_задачи>`
- [x] **Полное описание задачи**: Я предоставил полное описание задачи в теле pull request
- [x] **clang-format**: Мои изменения успешно проходят `clang-format` локально в моем форке (нет ошибок форматирования)
- [x] **clang-tidy**: Мои изменения успешно проходят `clang-tidy` локально в моем форке (нет предупреждений/ошибок)
- [x] **Функциональные тесты**: Все функциональные тесты успешно проходят локально на моей машине
- [x] **Тесты производительности**: Все тесты производительности успешно проходят локально на моей машине
- [x] **Ветка**: Я работаю в ветке, названной точно так же, как директория моей задачи
  (например, `nesterov_a_vector_sum`), а не в `master`
- [x] **Правдивое содержание**: Я подтверждаю, что все сведения, указанные в этом pull request, являются точными и
  достоверными

<!--
ПРИМЕЧАНИЕ: Ложные сведения в этом чек-листе могут привести к отклонению PR и получению нулевого балла
за соответствующую задачу.
-->
